### PR TITLE
Issue 990

### DIFF
--- a/experiments/issue990/2021-01-25-A-satisficing.py
+++ b/experiments/issue990/2021-01-25-A-satisficing.py
@@ -9,7 +9,7 @@ from lab.environments import LocalEnvironment, BaselSlurmEnvironment
 
 REVISIONS = [
     "main",
-    "69694b45",
+    "c802eb8d",
 ]
 
 CONFIGS = [

--- a/experiments/issue990/2021-01-25-A-satisficing.py
+++ b/experiments/issue990/2021-01-25-A-satisficing.py
@@ -1,0 +1,54 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import common_setup
+
+import os
+
+from lab.environments import LocalEnvironment, BaselSlurmEnvironment
+
+REVISIONS = [
+    "main",
+    "69694b45",
+]
+
+CONFIGS = [
+    common_setup.IssueConfig("lama-first", [],
+                             driver_options=["--alias", "lama-first"]),
+]
+
+BENCHMARKS_DIR = os.environ["DOWNWARD_BENCHMARKS"]
+REPO = os.environ["DOWNWARD_REPO"]
+
+if common_setup.is_running_on_cluster():
+    SUITE = common_setup.DEFAULT_SATISFICING_SUITE
+    ENVIRONMENT = BaselSlurmEnvironment(
+        partition="infai_2",
+        email="tho.keller@unibas.ch",
+        export=["PATH", "DOWNWARD_BENCHMARKS"],
+    )
+else:
+    SUITE = common_setup.IssueExperiment.DEFAULT_TEST_SUITE
+    ENVIRONMENT = LocalEnvironment(processes=2)
+
+exp = common_setup.IssueExperiment(
+    revisions=REVISIONS,
+    configs=CONFIGS,
+    environment=ENVIRONMENT,
+)
+
+exp.add_suite(BENCHMARKS_DIR, SUITE)
+
+exp.add_parser(exp.ANYTIME_SEARCH_PARSER)
+exp.add_parser(exp.EXITCODE_PARSER)
+exp.add_parser(exp.PLANNER_PARSER)
+exp.add_parser(exp.SINGLE_SEARCH_PARSER)
+
+exp.add_step("build", exp.build)
+exp.add_step("start", exp.start_runs)
+exp.add_fetcher(name="fetch")
+exp.add_absolute_report_step()
+exp.add_parse_again_step()
+
+exp.run_steps()
+

--- a/experiments/issue990/2021-01-25-B-optimal.py
+++ b/experiments/issue990/2021-01-25-B-optimal.py
@@ -9,7 +9,7 @@ from lab.environments import LocalEnvironment, BaselSlurmEnvironment
 
 REVISIONS = [
     "main",
-    "69694b45",
+    "c802eb8d",
 ]
 
 CONFIGS = [

--- a/experiments/issue990/2021-01-25-B-optimal.py
+++ b/experiments/issue990/2021-01-25-B-optimal.py
@@ -1,0 +1,53 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import common_setup
+
+import os
+
+from lab.environments import LocalEnvironment, BaselSlurmEnvironment
+
+REVISIONS = [
+    "main",
+    "69694b45",
+]
+
+CONFIGS = [
+    common_setup.IssueConfig("seq-opt-bjolp", [],
+                             driver_options=["--alias", "seq-opt-bjolp"]),
+]
+
+BENCHMARKS_DIR = os.environ["DOWNWARD_BENCHMARKS"]
+REPO = os.environ["DOWNWARD_REPO"]
+
+if common_setup.is_running_on_cluster():
+    SUITE = common_setup.DEFAULT_OPTIMAL_SUITE
+    ENVIRONMENT = BaselSlurmEnvironment(
+        partition="infai_2",
+        email="tho.keller@unibas.ch",
+        export=["PATH", "DOWNWARD_BENCHMARKS"],
+    )
+else:
+    SUITE = common_setup.IssueExperiment.DEFAULT_TEST_SUITE
+    ENVIRONMENT = LocalEnvironment(processes=2)
+
+exp = common_setup.IssueExperiment(
+    revisions=REVISIONS,
+    configs=CONFIGS,
+    environment=ENVIRONMENT,
+)
+
+exp.add_suite(BENCHMARKS_DIR, SUITE)
+
+exp.add_parser(exp.EXITCODE_PARSER)
+exp.add_parser(exp.PLANNER_PARSER)
+exp.add_parser(exp.SINGLE_SEARCH_PARSER)
+
+exp.add_step("build", exp.build)
+exp.add_step("start", exp.start_runs)
+exp.add_fetcher(name="fetch")
+exp.add_absolute_report_step()
+exp.add_parse_again_step()
+
+exp.run_steps()
+

--- a/experiments/issue990/common_setup.py
+++ b/experiments/issue990/common_setup.py
@@ -1,0 +1,395 @@
+# -*- coding: utf-8 -*-
+
+import itertools
+import os
+import platform
+import subprocess
+import sys
+
+from lab.experiment import ARGPARSER
+from lab import tools
+
+from downward.experiment import FastDownwardExperiment
+from downward.reports.absolute import AbsoluteReport
+from downward.reports.compare import ComparativeReport
+from downward.reports.scatter import ScatterPlotReport
+
+
+def parse_args():
+    ARGPARSER.add_argument(
+        "--test",
+        choices=["yes", "no", "auto"],
+        default="auto",
+        dest="test_run",
+        help="test experiment locally on a small suite if --test=yes or "
+             "--test=auto and we are not on a cluster")
+    return ARGPARSER.parse_args()
+
+ARGS = parse_args()
+
+
+DEFAULT_OPTIMAL_SUITE = [
+    'agricola-opt18-strips', 'airport', 'barman-opt11-strips',
+    'barman-opt14-strips', 'blocks', 'childsnack-opt14-strips',
+    'data-network-opt18-strips', 'depot', 'driverlog',
+    'elevators-opt08-strips', 'elevators-opt11-strips',
+    'floortile-opt11-strips', 'floortile-opt14-strips', 'freecell',
+    'ged-opt14-strips', 'grid', 'gripper', 'hiking-opt14-strips',
+    'logistics00', 'logistics98', 'miconic', 'movie', 'mprime',
+    'mystery', 'nomystery-opt11-strips', 'openstacks-opt08-strips',
+    'openstacks-opt11-strips', 'openstacks-opt14-strips',
+    'openstacks-strips', 'organic-synthesis-opt18-strips',
+    'organic-synthesis-split-opt18-strips', 'parcprinter-08-strips',
+    'parcprinter-opt11-strips', 'parking-opt11-strips',
+    'parking-opt14-strips', 'pathways-noneg', 'pegsol-08-strips',
+    'pegsol-opt11-strips', 'petri-net-alignment-opt18-strips',
+    'pipesworld-notankage', 'pipesworld-tankage', 'psr-small', 'rovers',
+    'satellite', 'scanalyzer-08-strips', 'scanalyzer-opt11-strips',
+    'snake-opt18-strips', 'sokoban-opt08-strips',
+    'sokoban-opt11-strips', 'spider-opt18-strips', 'storage',
+    'termes-opt18-strips', 'tetris-opt14-strips',
+    'tidybot-opt11-strips', 'tidybot-opt14-strips', 'tpp',
+    'transport-opt08-strips', 'transport-opt11-strips',
+    'transport-opt14-strips', 'trucks-strips', 'visitall-opt11-strips',
+    'visitall-opt14-strips', 'woodworking-opt08-strips',
+    'woodworking-opt11-strips', 'zenotravel']
+
+DEFAULT_SATISFICING_SUITE = [
+    'agricola-sat18-strips', 'airport', 'assembly',
+    'barman-sat11-strips', 'barman-sat14-strips', 'blocks',
+    'caldera-sat18-adl', 'caldera-split-sat18-adl', 'cavediving-14-adl',
+    'childsnack-sat14-strips', 'citycar-sat14-adl',
+    'data-network-sat18-strips', 'depot', 'driverlog',
+    'elevators-sat08-strips', 'elevators-sat11-strips',
+    'flashfill-sat18-adl', 'floortile-sat11-strips',
+    'floortile-sat14-strips', 'freecell', 'ged-sat14-strips', 'grid',
+    'gripper', 'hiking-sat14-strips', 'logistics00', 'logistics98',
+    'maintenance-sat14-adl', 'miconic', 'miconic-fulladl',
+    'miconic-simpleadl', 'movie', 'mprime', 'mystery',
+    'nomystery-sat11-strips', 'nurikabe-sat18-adl', 'openstacks',
+    'openstacks-sat08-adl', 'openstacks-sat08-strips',
+    'openstacks-sat11-strips', 'openstacks-sat14-strips',
+    'openstacks-strips', 'optical-telegraphs',
+    'organic-synthesis-sat18-strips',
+    'organic-synthesis-split-sat18-strips', 'parcprinter-08-strips',
+    'parcprinter-sat11-strips', 'parking-sat11-strips',
+    'parking-sat14-strips', 'pathways', 'pathways-noneg',
+    'pegsol-08-strips', 'pegsol-sat11-strips', 'philosophers',
+    'pipesworld-notankage', 'pipesworld-tankage', 'psr-large',
+    'psr-middle', 'psr-small', 'rovers', 'satellite',
+    'scanalyzer-08-strips', 'scanalyzer-sat11-strips', 'schedule',
+    'settlers-sat18-adl', 'snake-sat18-strips', 'sokoban-sat08-strips',
+    'sokoban-sat11-strips', 'spider-sat18-strips', 'storage',
+    'termes-sat18-strips', 'tetris-sat14-strips',
+    'thoughtful-sat14-strips', 'tidybot-sat11-strips', 'tpp',
+    'transport-sat08-strips', 'transport-sat11-strips',
+    'transport-sat14-strips', 'trucks', 'trucks-strips',
+    'visitall-sat11-strips', 'visitall-sat14-strips',
+    'woodworking-sat08-strips', 'woodworking-sat11-strips',
+    'zenotravel']
+
+
+def get_script():
+    """Get file name of main script."""
+    return tools.get_script_path()
+
+
+def get_script_dir():
+    """Get directory of main script.
+
+    Usually a relative directory (depends on how it was called by the user.)"""
+    return os.path.dirname(get_script())
+
+
+def get_experiment_name():
+    """Get name for experiment.
+
+    Derived from the absolute filename of the main script, e.g.
+    "/ham/spam/eggs.py" => "spam-eggs"."""
+    script = os.path.abspath(get_script())
+    script_dir = os.path.basename(os.path.dirname(script))
+    script_base = os.path.splitext(os.path.basename(script))[0]
+    return "%s-%s" % (script_dir, script_base)
+
+
+def get_data_dir():
+    """Get data dir for the experiment.
+
+    This is the subdirectory "data" of the directory containing
+    the main script."""
+    return os.path.join(get_script_dir(), "data", get_experiment_name())
+
+
+def get_repo_base():
+    """Get base directory of the repository, as an absolute path.
+
+    Search upwards in the directory tree from the main script until a
+    directory with a subdirectory named ".git" is found.
+
+    Abort if the repo base cannot be found."""
+    path = os.path.abspath(get_script_dir())
+    while os.path.dirname(path) != path:
+        if os.path.exists(os.path.join(path, ".git")):
+            return path
+        path = os.path.dirname(path)
+    sys.exit("repo base could not be found")
+
+
+def is_running_on_cluster():
+    node = platform.node()
+    return node.endswith(".scicore.unibas.ch") or node.endswith(".cluster.bc2.ch")
+
+
+def is_test_run():
+    return ARGS.test_run == "yes" or (
+        ARGS.test_run == "auto" and not is_running_on_cluster())
+
+
+def get_algo_nick(revision, config_nick):
+    return "{revision}-{config_nick}".format(**locals())
+
+
+class IssueConfig(object):
+    """Hold information about a planner configuration.
+
+    See FastDownwardExperiment.add_algorithm() for documentation of the
+    constructor's options.
+
+    """
+    def __init__(self, nick, component_options,
+                 build_options=None, driver_options=None):
+        self.nick = nick
+        self.component_options = component_options
+        self.build_options = build_options
+        self.driver_options = driver_options
+
+
+class IssueExperiment(FastDownwardExperiment):
+    """Subclass of FastDownwardExperiment with some convenience features."""
+
+    DEFAULT_TEST_SUITE = ["depot:p01.pddl", "gripper:prob01.pddl"]
+
+    DEFAULT_TABLE_ATTRIBUTES = [
+        "cost",
+        "coverage",
+        "error",
+        "evaluations",
+        "expansions",
+        "expansions_until_last_jump",
+        "initial_h_value",
+        "generated",
+        "memory",
+        "planner_memory",
+        "planner_time",
+        "quality",
+        "run_dir",
+        "score_evaluations",
+        "score_expansions",
+        "score_generated",
+        "score_memory",
+        "score_search_time",
+        "score_total_time",
+        "search_time",
+        "total_time",
+        ]
+
+    DEFAULT_SCATTER_PLOT_ATTRIBUTES = [
+        "evaluations",
+        "expansions",
+        "expansions_until_last_jump",
+        "initial_h_value",
+        "memory",
+        "search_time",
+        "total_time",
+        ]
+
+    PORTFOLIO_ATTRIBUTES = [
+        "cost",
+        "coverage",
+        "error",
+        "plan_length",
+        "run_dir",
+        ]
+
+    def __init__(self, revisions=None, configs=None, path=None, **kwargs):
+        """
+
+        You can either specify both *revisions* and *configs* or none
+        of them. If they are omitted, you will need to call
+        exp.add_algorithm() manually.
+
+        If *revisions* is given, it must be a non-empty list of
+        revision identifiers, which specify which planner versions to
+        use in the experiment. The same versions are used for
+        translator, preprocessor and search. ::
+
+            IssueExperiment(revisions=["issue123", "4b3d581643"], ...)
+
+        If *configs* is given, it must be a non-empty list of
+        IssueConfig objects. ::
+
+            IssueExperiment(..., configs=[
+                IssueConfig("ff", ["--search", "eager_greedy(ff())"]),
+                IssueConfig(
+                    "lama", [],
+                    driver_options=["--alias", "seq-sat-lama-2011"]),
+            ])
+
+        If *path* is specified, it must be the path to where the
+        experiment should be built (e.g.
+        /home/john/experiments/issue123/exp01/). If omitted, the
+        experiment path is derived automatically from the main
+        script's filename. Example::
+
+            script = experiments/issue123/exp01.py -->
+            path = experiments/issue123/data/issue123-exp01/
+
+        """
+
+        path = path or get_data_dir()
+
+        FastDownwardExperiment.__init__(self, path=path, **kwargs)
+
+        if (revisions and not configs) or (not revisions and configs):
+            raise ValueError(
+                "please provide either both or none of revisions and configs")
+
+        for rev in revisions:
+            for config in configs:
+                self.add_algorithm(
+                    get_algo_nick(rev, config.nick),
+                    get_repo_base(),
+                    rev,
+                    config.component_options,
+                    build_options=config.build_options,
+                    driver_options=config.driver_options)
+
+        self._revisions = revisions
+        self._configs = configs
+
+    @classmethod
+    def _is_portfolio(cls, config_nick):
+        return "fdss" in config_nick
+
+    @classmethod
+    def get_supported_attributes(cls, config_nick, attributes):
+        if cls._is_portfolio(config_nick):
+            return [attr for attr in attributes
+                    if attr in cls.PORTFOLIO_ATTRIBUTES]
+        return attributes
+
+    def add_absolute_report_step(self, **kwargs):
+        """Add step that makes an absolute report.
+
+        Absolute reports are useful for experiments that don't compare
+        revisions.
+
+        The report is written to the experiment evaluation directory.
+
+        All *kwargs* will be passed to the AbsoluteReport class. If the
+        keyword argument *attributes* is not specified, a default list
+        of attributes is used. ::
+
+            exp.add_absolute_report_step(attributes=["coverage"])
+
+        """
+        kwargs.setdefault("attributes", self.DEFAULT_TABLE_ATTRIBUTES)
+        report = AbsoluteReport(**kwargs)
+        outfile = os.path.join(
+            self.eval_dir,
+            get_experiment_name() + "." + report.output_format)
+        self.add_report(report, outfile=outfile)
+        self.add_step(
+            'publish-absolute-report', subprocess.call, ['publish', outfile])
+
+    def add_comparison_table_step(self, **kwargs):
+        """Add a step that makes pairwise revision comparisons.
+
+        Create comparative reports for all pairs of Fast Downward
+        revisions. Each report pairs up the runs of the same config and
+        lists the two absolute attribute values and their difference
+        for all attributes in kwargs["attributes"].
+
+        All *kwargs* will be passed to the CompareConfigsReport class.
+        If the keyword argument *attributes* is not specified, a
+        default list of attributes is used. ::
+
+            exp.add_comparison_table_step(attributes=["coverage"])
+
+        """
+        kwargs.setdefault("attributes", self.DEFAULT_TABLE_ATTRIBUTES)
+
+        def make_comparison_tables():
+            for rev1, rev2 in itertools.combinations(self._revisions, 2):
+                compared_configs = []
+                for config in self._configs:
+                    config_nick = config.nick
+                    compared_configs.append(
+                        ("%s-%s" % (rev1, config_nick),
+                         "%s-%s" % (rev2, config_nick),
+                         "Diff (%s)" % config_nick))
+                report = ComparativeReport(compared_configs, **kwargs)
+                outfile = os.path.join(
+                    self.eval_dir,
+                    "%s-%s-%s-compare.%s" % (
+                        self.name, rev1, rev2, report.output_format))
+                report(self.eval_dir, outfile)
+
+        def publish_comparison_tables():
+            for rev1, rev2 in itertools.combinations(self._revisions, 2):
+                outfile = os.path.join(
+                    self.eval_dir,
+                    "%s-%s-%s-compare.html" % (self.name, rev1, rev2))
+                subprocess.call(["publish", outfile])
+
+        self.add_step("make-comparison-tables", make_comparison_tables)
+        self.add_step(
+            "publish-comparison-tables", publish_comparison_tables)
+
+    def add_scatter_plot_step(self, relative=False, attributes=None, additional=[]):
+        """Add step creating (relative) scatter plots for all revision pairs.
+
+        Create a scatter plot for each combination of attribute,
+        configuration and revisions pair. If *attributes* is not
+        specified, a list of common scatter plot attributes is used.
+        For portfolios all attributes except "cost", "coverage" and
+        "plan_length" will be ignored. ::
+
+            exp.add_scatter_plot_step(attributes=["expansions"])
+
+        """
+        if relative:
+            scatter_dir = os.path.join(self.eval_dir, "scatter-relative")
+            step_name = "make-relative-scatter-plots"
+        else:
+            scatter_dir = os.path.join(self.eval_dir, "scatter-absolute")
+            step_name = "make-absolute-scatter-plots"
+        if attributes is None:
+            attributes = self.DEFAULT_SCATTER_PLOT_ATTRIBUTES
+
+        def make_scatter_plot(config_nick, rev1, rev2, attribute, config_nick2=None):
+            name = "-".join([self.name, rev1, rev2, attribute, config_nick])
+            if config_nick2 is not None:
+                name += "-" + config_nick2
+            print("Make scatter plot for", name)
+            algo1 = get_algo_nick(rev1, config_nick)
+            algo2 = get_algo_nick(rev2, config_nick if config_nick2 is None else config_nick2)
+            report = ScatterPlotReport(
+                filter_algorithm=[algo1, algo2],
+                attributes=[attribute],
+                relative=relative,
+                get_category=lambda run1, run2: run1["domain"])
+            report(
+                self.eval_dir,
+                os.path.join(scatter_dir, rev1 + "-" + rev2, name))
+
+        def make_scatter_plots():
+            for config in self._configs:
+                for rev1, rev2 in itertools.combinations(self._revisions, 2):
+                    for attribute in self.get_supported_attributes(
+                            config.nick, attributes):
+                        make_scatter_plot(config.nick, rev1, rev2, attribute)
+            for nick1, nick2, rev1, rev2, attribute in additional:
+                make_scatter_plot(nick1, rev1, rev2, attribute, config_nick2=nick2)
+
+        self.add_step(step_name, lambda: make_scatter_plots)

--- a/src/search/DownwardFiles.cmake
+++ b/src/search/DownwardFiles.cmake
@@ -692,6 +692,7 @@ fast_downward_plugin(
         landmarks/landmark_factory
         landmarks/landmark_factory_h_m
         landmarks/landmark_factory_merged
+        landmarks/landmark_factory_relaxation
         landmarks/landmark_factory_rpg_exhaust
         landmarks/landmark_factory_rpg_sasp
         landmarks/landmark_factory_zhu_givan

--- a/src/search/landmarks/landmark_factory.cc
+++ b/src/search/landmarks/landmark_factory.cc
@@ -63,10 +63,11 @@ shared_ptr<LandmarkGraph> LandmarkFactory::compute_lm_graph(
     TaskProxy task_proxy(*task);
 
     lm_graph = make_shared<LandmarkGraph>(task_proxy);
-    Exploration exploration(task_proxy);
-    generate_landmarks(task, exploration);
+
+    generate_landmarks(task);
 
     // the following replaces the old "build_lm_graph"
+    Exploration exploration(task_proxy);
     generate(task_proxy, exploration);
     utils::g_log << "Landmarks generation time: " << lm_generation_timer << endl;
     if (lm_graph->number_of_landmarks() == 0)
@@ -107,7 +108,7 @@ void LandmarkFactory::generate(const TaskProxy &task_proxy, Exploration &explora
 bool LandmarkFactory::achieves_non_conditional(const OperatorProxy &o,
                                                const LandmarkNode *lmp) const {
     /* Test whether the landmark is achieved by the operator unconditionally.
-    A disjunctive landmarks is achieved if one of its disjuncts is achieved. */
+    A disjunctive landmark is achieved if one of its disjuncts is achieved. */
     assert(lmp);
     for (EffectProxy effect: o.get_effects()) {
         for (const FactPair &lm_fact : lmp->facts) {
@@ -199,7 +200,7 @@ void LandmarkFactory::add_operator_and_propositions_to_list(const OperatorProxy 
 bool LandmarkFactory::is_causal_landmark(const TaskProxy &task_proxy, Exploration &exploration,
                                          const LandmarkNode &landmark) const {
     /* Test whether the relaxed planning task is unsolvable without using any operator
-       that has "landmark" has a precondition.
+       that has "landmark" as a precondition.
        Similar to "relaxed_task_solvable" above.
      */
 

--- a/src/search/landmarks/landmark_factory.cc
+++ b/src/search/landmarks/landmark_factory.cc
@@ -758,19 +758,6 @@ int LandmarkFactory::calculate_lms_cost() const {
     return result;
 }
 
-void LandmarkFactory::compute_predecessor_information(
-    const TaskProxy &task_proxy,
-    Exploration &exploration,
-    LandmarkNode *bp,
-    vector<vector<int>> &lvl_var,
-    vector<utils::HashMap<FactPair, int>> &lvl_op) {
-    /* Collect information at what time step propositions can be reached
-    (in lvl_var) in a relaxed plan that excludes bp, and similarly
-    when operators can be applied (in lvl_op).  */
-
-    relaxed_task_solvable(task_proxy, exploration, lvl_var, lvl_op, true, bp);
-}
-
 void LandmarkFactory::calc_achievers(const TaskProxy &task_proxy, Exploration &exploration) {
     VariablesProxy variables = task_proxy.get_variables();
     for (auto &lmn : lm_graph->get_nodes()) {
@@ -784,7 +771,7 @@ void LandmarkFactory::calc_achievers(const TaskProxy &task_proxy, Exploration &e
 
         vector<vector<int>> lvl_var;
         vector<utils::HashMap<FactPair, int>> lvl_op;
-        compute_predecessor_information(task_proxy, exploration, lmn.get(), lvl_var, lvl_op);
+        relaxed_task_solvable(task_proxy, exploration, lvl_var, lvl_op, true, lmn.get());
 
         for (int op_or_axom_id : lmn->possible_achievers) {
             OperatorProxy op = get_operator_or_axiom(task_proxy, op_or_axom_id);

--- a/src/search/landmarks/landmark_factory.cc
+++ b/src/search/landmarks/landmark_factory.cc
@@ -2,7 +2,6 @@
 
 #include "landmark_graph.h"
 
-#include "exploration.h"
 #include "util.h"
 
 #include "../option_parser.h"
@@ -20,14 +19,16 @@ using namespace std;
 
 namespace landmarks {
 LandmarkFactory::LandmarkFactory(const options::Options &opts)
-    : lm_graph_task(nullptr),
-      reasonable_orders(opts.get<bool>("reasonable_orders")),
+    : reasonable_orders(opts.get<bool>("reasonable_orders")),
       only_causal_landmarks(opts.get<bool>("only_causal_landmarks")),
       disjunctive_landmarks(opts.get<bool>("disjunctive_landmarks")),
       conjunctive_landmarks(opts.get<bool>("conjunctive_landmarks")),
-      no_orders(opts.get<bool>("no_orders")) {
+      no_orders(opts.get<bool>("no_orders")),
+      lm_graph_task(nullptr) {
 }
 /*
+  TODO: Update this comment
+
   Note: To allow reusing landmark graphs, we use the following temporary
   solution.
 
@@ -61,14 +62,9 @@ shared_ptr<LandmarkGraph> LandmarkFactory::compute_lm_graph(
     utils::Timer lm_generation_timer;
 
     TaskProxy task_proxy(*task);
-
     lm_graph = make_shared<LandmarkGraph>(task_proxy);
-
     generate_landmarks(task);
 
-    // the following replaces the old "build_lm_graph"
-    Exploration exploration(task_proxy);
-    generate(task_proxy, exploration);
     utils::g_log << "Landmarks generation time: " << lm_generation_timer << endl;
     if (lm_graph->number_of_landmarks() == 0)
         utils::g_log << "Warning! No landmarks found. Task unsolvable?" << endl;
@@ -83,45 +79,6 @@ shared_ptr<LandmarkGraph> LandmarkFactory::compute_lm_graph(
     return lm_graph;
 }
 
-void LandmarkFactory::generate(const TaskProxy &task_proxy, Exploration &exploration) {
-    if (only_causal_landmarks)
-        discard_noncausal_landmarks(task_proxy, exploration);
-    if (!disjunctive_landmarks)
-        discard_disjunctive_landmarks();
-    if (!conjunctive_landmarks)
-        discard_conjunctive_landmarks();
-    lm_graph->set_landmark_ids();
-
-    if (no_orders)
-        discard_all_orderings();
-    else if (reasonable_orders) {
-        utils::g_log << "approx. reasonable orders" << endl;
-        approximate_reasonable_orders(task_proxy, false);
-        utils::g_log << "approx. obedient reasonable orders" << endl;
-        approximate_reasonable_orders(task_proxy, true);
-    }
-    mk_acyclic_graph();
-    lm_graph->set_landmark_cost(calculate_lms_cost());
-    calc_achievers(task_proxy, exploration);
-}
-
-bool LandmarkFactory::achieves_non_conditional(const OperatorProxy &o,
-                                               const LandmarkNode *lmp) const {
-    /* Test whether the landmark is achieved by the operator unconditionally.
-    A disjunctive landmark is achieved if one of its disjuncts is achieved. */
-    assert(lmp);
-    for (EffectProxy effect: o.get_effects()) {
-        for (const FactPair &lm_fact : lmp->facts) {
-            FactProxy effect_fact = effect.get_fact();
-            if (effect_fact.get_pair() == lm_fact) {
-                if (effect.get_conditions().empty())
-                    return true;
-            }
-        }
-    }
-    return false;
-}
-
 bool LandmarkFactory::is_landmark_precondition(const OperatorProxy &op,
                                                const LandmarkNode *lmp) const {
     /* Test whether the landmark is used by the operator as a precondition.
@@ -133,105 +90,6 @@ bool LandmarkFactory::is_landmark_precondition(const OperatorProxy &op,
                 return true;
         }
     }
-    return false;
-}
-
-bool LandmarkFactory::relaxed_task_solvable(const TaskProxy &task_proxy,
-                                            Exploration &exploration,
-                                            vector<vector<int>> &lvl_var,
-                                            vector<utils::HashMap<FactPair, int>> &lvl_op,
-                                            bool level_out, const LandmarkNode *exclude, bool compute_lvl_op) const {
-    /* Test whether the relaxed planning task is solvable without achieving the propositions in
-     "exclude" (do not apply operators that would add a proposition from "exclude").
-     As a side effect, collect in lvl_var and lvl_op the earliest possible point in time
-     when a proposition / operator can be achieved / become applicable in the relaxed task.
-     */
-
-    OperatorsProxy operators = task_proxy.get_operators();
-    AxiomsProxy axioms = task_proxy.get_axioms();
-    // Initialize lvl_op and lvl_var to numeric_limits<int>::max()
-    if (compute_lvl_op) {
-        lvl_op.resize(operators.size() + axioms.size());
-        for (OperatorProxy op : operators) {
-            add_operator_and_propositions_to_list(op, lvl_op);
-        }
-        for (OperatorProxy axiom : axioms) {
-            add_operator_and_propositions_to_list(axiom, lvl_op);
-        }
-    }
-    VariablesProxy variables = task_proxy.get_variables();
-    lvl_var.resize(variables.size());
-    for (VariableProxy var : variables) {
-        lvl_var[var.get_id()].resize(var.get_domain_size(),
-                                     numeric_limits<int>::max());
-    }
-    // Extract propositions from "exclude"
-    unordered_set<int> exclude_op_ids;
-    vector<FactPair> exclude_props;
-    if (exclude) {
-        for (OperatorProxy op : operators) {
-            if (achieves_non_conditional(op, exclude))
-                exclude_op_ids.insert(op.get_id());
-        }
-        exclude_props.insert(exclude_props.end(),
-                             exclude->facts.begin(), exclude->facts.end());
-    }
-    // Do relaxed exploration
-    exploration.compute_reachability_with_excludes(
-        lvl_var, lvl_op, level_out, exclude_props, exclude_op_ids, compute_lvl_op);
-
-    // Test whether all goal propositions have a level of less than numeric_limits<int>::max()
-    for (FactProxy goal : task_proxy.get_goals())
-        if (lvl_var[goal.get_variable().get_id()][goal.get_value()] ==
-            numeric_limits<int>::max())
-            return false;
-
-    return true;
-}
-
-void LandmarkFactory::add_operator_and_propositions_to_list(const OperatorProxy &op,
-                                                            vector<utils::HashMap<FactPair, int>> &lvl_op) const {
-    int op_or_axiom_id = get_operator_or_axiom_id(op);
-    for (EffectProxy effect : op.get_effects()) {
-        lvl_op[op_or_axiom_id].emplace(effect.get_fact().get_pair(), numeric_limits<int>::max());
-    }
-}
-
-bool LandmarkFactory::is_causal_landmark(const TaskProxy &task_proxy, Exploration &exploration,
-                                         const LandmarkNode &landmark) const {
-    /* Test whether the relaxed planning task is unsolvable without using any operator
-       that has "landmark" as a precondition.
-       Similar to "relaxed_task_solvable" above.
-     */
-
-    if (landmark.in_goal)
-        return true;
-    vector<vector<int>> lvl_var;
-    vector<utils::HashMap<FactPair, int>> lvl_op;
-    // Initialize lvl_var to numeric_limits<int>::max()
-    VariablesProxy variables = task_proxy.get_variables();
-    lvl_var.resize(variables.size());
-    for (VariableProxy var : variables) {
-        lvl_var[var.get_id()].resize(var.get_domain_size(),
-                                     numeric_limits<int>::max());
-    }
-    unordered_set<int> exclude_op_ids;
-    vector<FactPair> exclude_props;
-    for (OperatorProxy op : task_proxy.get_operators()) {
-        if (is_landmark_precondition(op, &landmark)) {
-            exclude_op_ids.insert(op.get_id());
-        }
-    }
-    // Do relaxed exploration
-    exploration.compute_reachability_with_excludes(
-        lvl_var, lvl_op, true, exclude_props, exclude_op_ids, false);
-
-    // Test whether all goal propositions have a level of less than numeric_limits<int>::max()
-    for (FactProxy goal : task_proxy.get_goals())
-        if (lvl_var[goal.get_variable().get_id()][goal.get_value()] ==
-            numeric_limits<int>::max())
-            return true;
-
     return false;
 }
 
@@ -607,17 +465,6 @@ void LandmarkFactory::edge_add(LandmarkNode &from, LandmarkNode &to,
     assert(to.parents.find(&from) != to.parents.end());
 }
 
-void LandmarkFactory::discard_noncausal_landmarks(const TaskProxy &task_proxy, Exploration &exploration) {
-    int num_all_landmarks = lm_graph->number_of_landmarks();
-    lm_graph->remove_node_if(
-        [this, &task_proxy, &exploration](const LandmarkNode &node) {
-            return !is_causal_landmark(task_proxy, exploration, node);
-        });
-    int num_causal_landmarks = lm_graph->number_of_landmarks();
-    utils::g_log << "Discarded " << num_all_landmarks - num_causal_landmarks
-                 << " non-causal landmarks" << endl;
-}
-
 void LandmarkFactory::discard_disjunctive_landmarks() {
     /*
       Using disjunctive landmarks during landmark generation can be beneficial
@@ -756,31 +603,6 @@ int LandmarkFactory::calculate_lms_cost() const {
         result += lmn->min_cost;
 
     return result;
-}
-
-void LandmarkFactory::calc_achievers(const TaskProxy &task_proxy, Exploration &exploration) {
-    VariablesProxy variables = task_proxy.get_variables();
-    for (auto &lmn : lm_graph->get_nodes()) {
-        for (const FactPair &lm_fact : lmn->facts) {
-            const vector<int> &ops = lm_graph->get_operators_including_eff(lm_fact);
-            lmn->possible_achievers.insert(ops.begin(), ops.end());
-
-            if (variables[lm_fact.var].is_derived())
-                lmn->is_derived = true;
-        }
-
-        vector<vector<int>> lvl_var;
-        vector<utils::HashMap<FactPair, int>> lvl_op;
-        relaxed_task_solvable(task_proxy, exploration, lvl_var, lvl_op, true, lmn.get());
-
-        for (int op_or_axom_id : lmn->possible_achievers) {
-            OperatorProxy op = get_operator_or_axiom(task_proxy, op_or_axom_id);
-
-            if (_possibly_reaches_lm(op, lvl_var, lmn.get())) {
-                lmn->first_achievers.insert(op_or_axom_id);
-            }
-        }
-    }
 }
 
 void _add_options_to_parser(OptionParser &parser) {

--- a/src/search/landmarks/landmark_factory.h
+++ b/src/search/landmarks/landmark_factory.h
@@ -20,9 +20,6 @@ class Options;
 
 namespace landmarks {
 class Exploration;
-class LandmarkGraph;
-class LandmarkNode;
-enum class EdgeType;
 
 class LandmarkFactory {
 public:
@@ -30,7 +27,7 @@ public:
     virtual ~LandmarkFactory() = default;
 
     LandmarkFactory(const LandmarkFactory &) = delete;
-
+    
     std::shared_ptr<LandmarkGraph> compute_lm_graph(const std::shared_ptr<AbstractTask> &task);
 
     bool use_disjunctive_landmarks() const {return disjunctive_landmarks;}

--- a/src/search/landmarks/landmark_factory.h
+++ b/src/search/landmarks/landmark_factory.h
@@ -40,11 +40,6 @@ protected:
     bool use_orders() const {return !no_orders;}   // only needed by HMLandmark
 
     void edge_add(LandmarkNode &from, LandmarkNode &to, EdgeType type);
-    void compute_predecessor_information(const TaskProxy &task_proxy,
-                                         Exploration &exploration,
-                                         LandmarkNode *bp,
-                                         std::vector<std::vector<int>> &lvl_var,
-                                         std::vector<utils::HashMap<FactPair, int>> &lvl_op);
     inline bool relaxed_task_solvable(const TaskProxy &task_proxy, Exploration &exploration,
                                       bool level_out,
                                       const LandmarkNode *exclude,
@@ -53,6 +48,12 @@ protected:
         std::vector<utils::HashMap<FactPair, int>> lvl_op;
         return relaxed_task_solvable(task_proxy, exploration, lvl_var, lvl_op, level_out, exclude, compute_lvl_op);
     }
+    bool relaxed_task_solvable(const TaskProxy &task_proxy, Exploration &exploration,
+                               std::vector<std::vector<int>> &lvl_var,
+                               std::vector<utils::HashMap<FactPair, int>> &lvl_op,
+                               bool level_out,
+                               const LandmarkNode *exclude,
+                               bool compute_lvl_op = false) const;
 
 private:
     AbstractTask *lm_graph_task;
@@ -90,12 +91,6 @@ private:
     int calculate_lms_cost() const;
     void collect_ancestors(std::unordered_set<LandmarkNode *> &result, LandmarkNode &node,
                            bool use_reasonable);
-    bool relaxed_task_solvable(const TaskProxy &task_proxy, Exploration &exploration,
-                               std::vector<std::vector<int>> &lvl_var,
-                               std::vector<utils::HashMap<FactPair, int>> &lvl_op,
-                               bool level_out,
-                               const LandmarkNode *exclude,
-                               bool compute_lvl_op = false) const;
     void add_operator_and_propositions_to_list(const OperatorProxy &op,
                                                std::vector<utils::HashMap<FactPair, int>> &lvl_op) const;
     bool is_causal_landmark(const TaskProxy &task_proxy, Exploration &exploration, const LandmarkNode &landmark) const;

--- a/src/search/landmarks/landmark_factory.h
+++ b/src/search/landmarks/landmark_factory.h
@@ -42,7 +42,7 @@ protected:
     const bool conjunctive_landmarks;
     const bool no_orders;
 
-    // TODO: directly use no_orders in LandmarkFactoryHM
+    // TODO: Directly use no_orders in LandmarkFactoryHM and remove this
     bool use_orders() const {return !no_orders;}   // only needed by HMLandmark
 
     // TODO: Move to the landmark graph
@@ -50,9 +50,7 @@ protected:
 
     // TODO: All of these do some sort of postprocessing of the landmark graph,
     //  and it appears reasonable that all can be combined with any landmark
-    //  factory. I don't think LandmarkFactory is the right place for this. For
-    //  the last one (calculate_lms_cost), I'm not even sure why it is needed
-    //  at all.
+    //  factory. I don't think LandmarkFactory is the right place for this.
     void discard_disjunctive_landmarks();
     void discard_conjunctive_landmarks();
     void discard_all_orderings();

--- a/src/search/landmarks/landmark_factory_h_m.cc
+++ b/src/search/landmarks/landmark_factory_h_m.cc
@@ -899,7 +899,7 @@ void LandmarkFactoryHM::add_lm_node(int set_index, bool goal) {
 }
 
 void LandmarkFactoryHM::generate_landmarks(
-    const shared_ptr<AbstractTask> &task, Exploration &) {
+    const shared_ptr<AbstractTask> &task) {
     TaskProxy task_proxy(*task);
     initialize(task_proxy);
     compute_h_m_landmarks(task_proxy);

--- a/src/search/landmarks/landmark_factory_h_m.cc
+++ b/src/search/landmarks/landmark_factory_h_m.cc
@@ -1,5 +1,7 @@
 #include "landmark_factory_h_m.h"
 
+#include "exploration.h"
+
 #include "../abstract_task.h"
 #include "../option_parser.h"
 #include "../plugin.h"
@@ -586,7 +588,82 @@ void LandmarkFactoryHM::initialize(const TaskProxy &task_proxy) {
     build_pm_ops(task_proxy);
 }
 
-void LandmarkFactoryHM::calc_achievers(const TaskProxy &task_proxy, Exploration &) {
+void LandmarkFactoryHM::generate(const TaskProxy &task_proxy) {
+    if (only_causal_landmarks) {
+        Exploration exploration(task_proxy);
+        discard_noncausal_landmarks(task_proxy, exploration);
+    }
+    if (!disjunctive_landmarks)
+        discard_disjunctive_landmarks();
+    if (!conjunctive_landmarks)
+        discard_conjunctive_landmarks();
+    lm_graph->set_landmark_ids();
+
+    if (no_orders)
+        discard_all_orderings();
+    else if (reasonable_orders) {
+        utils::g_log << "approx. reasonable orders" << endl;
+        approximate_reasonable_orders(task_proxy, false);
+        utils::g_log << "approx. obedient reasonable orders" << endl;
+        approximate_reasonable_orders(task_proxy, true);
+    }
+    mk_acyclic_graph();
+    lm_graph->set_landmark_cost(calculate_lms_cost());
+    calc_achievers(task_proxy);
+}
+
+void LandmarkFactoryHM::discard_noncausal_landmarks(
+    const TaskProxy &task_proxy, Exploration &exploration) {
+    int num_all_landmarks = lm_graph->number_of_landmarks();
+    lm_graph->remove_node_if(
+        [this, &task_proxy, &exploration](const LandmarkNode &node) {
+            return !is_causal_landmark(task_proxy, exploration, node);
+        });
+    int num_causal_landmarks = lm_graph->number_of_landmarks();
+    utils::g_log << "Discarded " << num_all_landmarks - num_causal_landmarks
+                 << " non-causal landmarks" << endl;
+}
+
+bool LandmarkFactoryHM::is_causal_landmark(
+    const TaskProxy &task_proxy, Exploration &exploration,
+    const LandmarkNode &landmark) const {
+    /* Test whether the relaxed planning task is unsolvable without using any operator
+       that has "landmark" as a precondition.
+       Similar to "relaxed_task_solvable" above.
+     */
+
+    if (landmark.in_goal)
+        return true;
+    vector<vector<int>> lvl_var;
+    vector<utils::HashMap<FactPair, int>> lvl_op;
+    // Initialize lvl_var to numeric_limits<int>::max()
+    VariablesProxy variables = task_proxy.get_variables();
+    lvl_var.resize(variables.size());
+    for (VariableProxy var : variables) {
+        lvl_var[var.get_id()].resize(var.get_domain_size(),
+                                     numeric_limits<int>::max());
+    }
+    unordered_set<int> exclude_op_ids;
+    vector<FactPair> exclude_props;
+    for (OperatorProxy op : task_proxy.get_operators()) {
+        if (is_landmark_precondition(op, &landmark)) {
+            exclude_op_ids.insert(op.get_id());
+        }
+    }
+    // Do relaxed exploration
+    exploration.compute_reachability_with_excludes(
+        lvl_var, lvl_op, true, exclude_props, exclude_op_ids, false);
+
+    // Test whether all goal propositions have a level of less than numeric_limits<int>::max()
+    for (FactProxy goal : task_proxy.get_goals())
+        if (lvl_var[goal.get_variable().get_id()][goal.get_value()] ==
+            numeric_limits<int>::max())
+            return true;
+
+    return false;
+}
+
+void LandmarkFactoryHM::calc_achievers(const TaskProxy &task_proxy) {
     utils::g_log << "Calculating achievers." << endl;
 
     OperatorsProxy operators = task_proxy.get_operators();

--- a/src/search/landmarks/landmark_factory_h_m.cc
+++ b/src/search/landmarks/landmark_factory_h_m.cc
@@ -1043,6 +1043,8 @@ void LandmarkFactoryHM::generate_landmarks(
         }
     }
     free_unneeded_memory();
+
+    generate(task_proxy);
 }
 
 bool LandmarkFactoryHM::supports_conditional_effects() const {

--- a/src/search/landmarks/landmark_factory_h_m.h
+++ b/src/search/landmarks/landmark_factory_h_m.h
@@ -59,8 +59,7 @@ using FluentSetToIntMap = std::map<FluentSet, int, FluentSetComparer>;
 class LandmarkFactoryHM : public LandmarkFactory {
     using TriggerSet = std::unordered_map<int, std::set<int>>;
 
-    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task,
-                                    Exploration &exploration) override;
+    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task) override;
 
     void compute_h_m_landmarks(const TaskProxy &task_proxy);
     void compute_noop_landmarks(int op_index, int noop_index,

--- a/src/search/landmarks/landmark_factory_h_m.h
+++ b/src/search/landmarks/landmark_factory_h_m.h
@@ -4,6 +4,8 @@
 #include "landmark_factory.h"
 
 namespace landmarks {
+class Exploration;
+
 using FluentSet = std::vector<FactPair>;
 
 std::ostream &
@@ -78,7 +80,16 @@ class LandmarkFactoryHM : public LandmarkFactory {
     bool interesting(const VariablesProxy &variables,
                      const FactPair &fact1,
                      const FactPair &fact2) const;
-    virtual void calc_achievers(const TaskProxy &task_proxy, Exploration &exploration) override;
+
+    void generate(const TaskProxy &task_proxy);
+
+    void discard_noncausal_landmarks(const TaskProxy &task_proxy,
+                                     Exploration &exploration);
+    bool is_causal_landmark(const TaskProxy &task_proxy,
+                            Exploration &exploration,
+                            const LandmarkNode &landmark) const;
+
+    void calc_achievers(const TaskProxy &task_proxy);
 
     void add_lm_node(int set_index, bool goal = false);
 

--- a/src/search/landmarks/landmark_factory_h_m.h
+++ b/src/search/landmarks/landmark_factory_h_m.h
@@ -83,8 +83,10 @@ class LandmarkFactoryHM : public LandmarkFactory {
 
     void generate(const TaskProxy &task_proxy);
 
+    // TODO: this is duplicated here and in LandmarkFactoryRelaxation
     void discard_noncausal_landmarks(const TaskProxy &task_proxy,
                                      Exploration &exploration);
+    // TODO: this is duplicated here and in LandmarkFactoryRelaxation
     bool is_causal_landmark(const TaskProxy &task_proxy,
                             Exploration &exploration,
                             const LandmarkNode &landmark) const;

--- a/src/search/landmarks/landmark_factory_merged.cc
+++ b/src/search/landmarks/landmark_factory_merged.cc
@@ -42,9 +42,11 @@ LandmarkNode *LandmarkFactoryMerged::get_matching_landmark(const LandmarkNode &l
 }
 
 void LandmarkFactoryMerged::generate_landmarks(
-    const shared_ptr<AbstractTask> &task, Exploration &) {
+    const shared_ptr<AbstractTask> &task) {
     utils::g_log << "Merging " << lm_factories.size() << " landmark graphs" << endl;
 
+    std::vector<std::shared_ptr<LandmarkGraph>> lm_graphs;
+    lm_graphs.reserve(lm_factories.size());
     for (const shared_ptr<LandmarkFactory> &lm_factory : lm_factories) {
         lm_graphs.push_back(lm_factory->compute_lm_graph(task));
     }

--- a/src/search/landmarks/landmark_factory_merged.cc
+++ b/src/search/landmarks/landmark_factory_merged.cc
@@ -1,6 +1,5 @@
 #include "landmark_factory_merged.h"
 
-#include "exploration.h"
 #include "landmark_graph.h"
 
 #include "../option_parser.h"
@@ -60,15 +59,20 @@ void LandmarkFactoryMerged::generate_landmarks(
             if (!node.conjunctive && !node.disjunctive && !lm_graph->landmark_exists(lm_fact)) {
                 LandmarkNode &new_node = lm_graph->landmark_add_simple(lm_fact);
                 new_node.in_goal = node.in_goal;
+                new_node.possible_achievers.insert(
+                    node.possible_achievers.begin(), node.possible_achievers.end());
+                new_node.first_achievers.insert(
+                    node.first_achievers.begin(), node.first_achievers.end());
+                new_node.is_derived = node.is_derived;
             }
         }
     }
 
-    // TODO: It seems that disjunctive landmarks are only added if none of its
-    //  facts is also there as a simple landmark. This should either be more
-    //  general (no subset is there as a disjunctive landmark) or be removed at
-    //  all (if orders are not considered, these can be removed).
-
+    // TODO: It seems that disjunctive landmarks are only added if none of the
+    //  facts it is made of is also there as a simple landmark. This should
+    //  either be more general (add only if none of its subset is already there)
+    //  or it should be done only upon request (e.g., heuristics that consider
+    //  orders might want to keep all landmarks).
     utils::g_log << "Adding disjunctive landmarks" << endl;
     for (size_t i = 0; i < lm_graphs.size(); ++i) {
         const LandmarkGraph::Nodes &nodes = lm_graphs[i]->get_nodes();
@@ -87,6 +91,11 @@ void LandmarkFactoryMerged::generate_landmarks(
                 if (!exists) {
                     LandmarkNode &new_node = lm_graph->landmark_add_disjunctive(lm_facts);
                     new_node.in_goal = node.in_goal;
+                    new_node.possible_achievers.insert(
+                        node.possible_achievers.begin(), node.possible_achievers.end());
+                    new_node.first_achievers.insert(
+                        node.first_achievers.begin(), node.first_achievers.end());
+                    new_node.is_derived = node.is_derived;
                 }
             } else if (node.conjunctive) {
                 cerr << "Don't know how to handle conjunctive landmarks yet" << endl;
@@ -128,8 +137,8 @@ void LandmarkFactoryMerged::generate(const TaskProxy &task_proxy) {
     //  have been removed in the individual landmark graphs. Since merging
     //  landmark graphs doesn't introduce any of these, it should not be
     //  necessary to do so again here, so these steps are omitted. For
-    //  reasonable orders, acyclicity of the landmark graph, the costs of
-    //  landmarks and the achievers we should also determine this.
+    //  reasonable orders, acyclicity of the landmark graph and the costs of
+    //  landmarks we should also determine this.
     if (reasonable_orders) {
         utils::g_log << "approx. reasonable orders" << endl;
         approximate_reasonable_orders(task_proxy, false);
@@ -138,116 +147,6 @@ void LandmarkFactoryMerged::generate(const TaskProxy &task_proxy) {
     }
     mk_acyclic_graph();
     lm_graph->set_landmark_cost(calculate_lms_cost());
-
-    // TODO: We should copy the achievers of each landmark when the individual
-    //  landmark graphs are merged. That way, we do not have to recompute them
-    //  here and get rid of the Exploration object (as well as the the methods
-    //  calc_achievers, relaxed_task_solvable, achieves_non_conditional and
-    //  add_operator_and_propositions_to_list).
-    calc_achievers(task_proxy);
-}
-
-void LandmarkFactoryMerged::calc_achievers(const TaskProxy &task_proxy) {
-    Exploration exploration(task_proxy);
-    VariablesProxy variables = task_proxy.get_variables();
-    for (auto &lmn : lm_graph->get_nodes()) {
-        for (const FactPair &lm_fact : lmn->facts) {
-            const vector<int> &ops = lm_graph->get_operators_including_eff(lm_fact);
-            lmn->possible_achievers.insert(ops.begin(), ops.end());
-
-            if (variables[lm_fact.var].is_derived())
-                lmn->is_derived = true;
-        }
-
-        vector<vector<int>> lvl_var;
-        vector<utils::HashMap<FactPair, int>> lvl_op;
-        relaxed_task_solvable(task_proxy, exploration, lvl_var, lvl_op, true, lmn.get());
-
-        for (int op_or_axom_id : lmn->possible_achievers) {
-            OperatorProxy op = get_operator_or_axiom(task_proxy, op_or_axom_id);
-
-            if (_possibly_reaches_lm(op, lvl_var, lmn.get())) {
-                lmn->first_achievers.insert(op_or_axom_id);
-            }
-        }
-    }
-}
-
-bool LandmarkFactoryMerged::relaxed_task_solvable(
-    const TaskProxy &task_proxy, Exploration &exploration,
-    vector<vector<int>> &lvl_var, vector<utils::HashMap<FactPair, int>> &lvl_op,
-    bool level_out, const LandmarkNode *exclude, bool compute_lvl_op) const {
-    /* Test whether the relaxed planning task is solvable without achieving the propositions in
-     "exclude" (do not apply operators that would add a proposition from "exclude").
-     As a side effect, collect in lvl_var and lvl_op the earliest possible point in time
-     when a proposition / operator can be achieved / become applicable in the relaxed task.
-     */
-
-    OperatorsProxy operators = task_proxy.get_operators();
-    AxiomsProxy axioms = task_proxy.get_axioms();
-    // Initialize lvl_op and lvl_var to numeric_limits<int>::max()
-    if (compute_lvl_op) {
-        lvl_op.resize(operators.size() + axioms.size());
-        for (OperatorProxy op : operators) {
-            add_operator_and_propositions_to_list(op, lvl_op);
-        }
-        for (OperatorProxy axiom : axioms) {
-            add_operator_and_propositions_to_list(axiom, lvl_op);
-        }
-    }
-    VariablesProxy variables = task_proxy.get_variables();
-    lvl_var.resize(variables.size());
-    for (VariableProxy var : variables) {
-        lvl_var[var.get_id()].resize(var.get_domain_size(),
-                                     numeric_limits<int>::max());
-    }
-    // Extract propositions from "exclude"
-    unordered_set<int> exclude_op_ids;
-    vector<FactPair> exclude_props;
-    if (exclude) {
-        for (OperatorProxy op : operators) {
-            if (achieves_non_conditional(op, exclude))
-                exclude_op_ids.insert(op.get_id());
-        }
-        exclude_props.insert(exclude_props.end(),
-                             exclude->facts.begin(), exclude->facts.end());
-    }
-    // Do relaxed exploration
-    exploration.compute_reachability_with_excludes(
-        lvl_var, lvl_op, level_out, exclude_props, exclude_op_ids, compute_lvl_op);
-
-    // Test whether all goal propositions have a level of less than numeric_limits<int>::max()
-    for (FactProxy goal : task_proxy.get_goals())
-        if (lvl_var[goal.get_variable().get_id()][goal.get_value()] ==
-            numeric_limits<int>::max())
-            return false;
-
-    return true;
-}
-
-bool LandmarkFactoryMerged::achieves_non_conditional(
-    const OperatorProxy &o, const LandmarkNode *lmp) const {
-    /* Test whether the landmark is achieved by the operator unconditionally.
-    A disjunctive landmark is achieved if one of its disjuncts is achieved. */
-    assert(lmp);
-    for (EffectProxy effect: o.get_effects()) {
-        for (const FactPair &lm_fact : lmp->facts) {
-            FactProxy effect_fact = effect.get_fact();
-            if (effect_fact.get_pair() == lm_fact) {
-                if (effect.get_conditions().empty())
-                    return true;
-            }
-        }
-    }
-    return false;
-}
-
-void LandmarkFactoryMerged::add_operator_and_propositions_to_list(
-    const OperatorProxy &op, vector<utils::HashMap<FactPair, int>> &lvl_op) const {
-    int op_or_axiom_id = get_operator_or_axiom_id(op);
-    for (EffectProxy effect : op.get_effects()) {
-        lvl_op[op_or_axiom_id].emplace(effect.get_fact().get_pair(), numeric_limits<int>::max());
-    }
 }
 
 bool LandmarkFactoryMerged::supports_conditional_effects() const {

--- a/src/search/landmarks/landmark_factory_merged.h
+++ b/src/search/landmarks/landmark_factory_merged.h
@@ -6,24 +6,11 @@
 #include <vector>
 
 namespace landmarks {
-class Exploration;
-
 class LandmarkFactoryMerged : public LandmarkFactory {
     std::vector<std::shared_ptr<LandmarkFactory>> lm_factories;
 
     virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task) override;
     void generate(const TaskProxy &task_proxy);
-    void calc_achievers(const TaskProxy &task_proxy);
-    bool relaxed_task_solvable(const TaskProxy &task_proxy, Exploration &exploration,
-                               std::vector<std::vector<int>> &lvl_var,
-                               std::vector<utils::HashMap<FactPair, int>> &lvl_op,
-                               bool level_out,
-                               const LandmarkNode *exclude,
-                               bool compute_lvl_op = false) const;
-    bool achieves_non_conditional(const OperatorProxy &o,
-                                  const LandmarkNode *lmp) const;
-    void add_operator_and_propositions_to_list(
-        const OperatorProxy &op, std::vector<utils::HashMap<FactPair, int>> &lvl_op) const;
     LandmarkNode *get_matching_landmark(const LandmarkNode &lm) const;
 public:
     explicit LandmarkFactoryMerged(const options::Options &opts);

--- a/src/search/landmarks/landmark_factory_merged.h
+++ b/src/search/landmarks/landmark_factory_merged.h
@@ -6,9 +6,6 @@
 #include <vector>
 
 namespace landmarks {
-class LandmarkGraph;
-class LandmarkNode;
-
 class LandmarkFactoryMerged : public LandmarkFactory {
     std::vector<std::shared_ptr<LandmarkGraph>> lm_graphs;
     std::vector<std::shared_ptr<LandmarkFactory>> lm_factories;

--- a/src/search/landmarks/landmark_factory_merged.h
+++ b/src/search/landmarks/landmark_factory_merged.h
@@ -7,10 +7,9 @@
 
 namespace landmarks {
 class LandmarkFactoryMerged : public LandmarkFactory {
-    std::vector<std::shared_ptr<LandmarkGraph>> lm_graphs;
     std::vector<std::shared_ptr<LandmarkFactory>> lm_factories;
 
-    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task, Exploration &exploration) override;
+    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task) override;
     LandmarkNode *get_matching_landmark(const LandmarkNode &lm) const;
 public:
     explicit LandmarkFactoryMerged(const options::Options &opts);

--- a/src/search/landmarks/landmark_factory_merged.h
+++ b/src/search/landmarks/landmark_factory_merged.h
@@ -6,10 +6,24 @@
 #include <vector>
 
 namespace landmarks {
+class Exploration;
+
 class LandmarkFactoryMerged : public LandmarkFactory {
     std::vector<std::shared_ptr<LandmarkFactory>> lm_factories;
 
     virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task) override;
+    void generate(const TaskProxy &task_proxy);
+    void calc_achievers(const TaskProxy &task_proxy);
+    bool relaxed_task_solvable(const TaskProxy &task_proxy, Exploration &exploration,
+                               std::vector<std::vector<int>> &lvl_var,
+                               std::vector<utils::HashMap<FactPair, int>> &lvl_op,
+                               bool level_out,
+                               const LandmarkNode *exclude,
+                               bool compute_lvl_op = false) const;
+    bool achieves_non_conditional(const OperatorProxy &o,
+                                  const LandmarkNode *lmp) const;
+    void add_operator_and_propositions_to_list(
+        const OperatorProxy &op, std::vector<utils::HashMap<FactPair, int>> &lvl_op) const;
     LandmarkNode *get_matching_landmark(const LandmarkNode &lm) const;
 public:
     explicit LandmarkFactoryMerged(const options::Options &opts);

--- a/src/search/landmarks/landmark_factory_relaxation.cc
+++ b/src/search/landmarks/landmark_factory_relaxation.cc
@@ -8,7 +8,7 @@ namespace landmarks {
 void LandmarkFactoryRelaxation::generate_landmarks(const std::shared_ptr<AbstractTask>& task) {
     TaskProxy task_proxy(*task);
     Exploration exploration(task_proxy);
-    generate_landmarks(task, exploration);
+    generate_relaxed_landmarks(task, exploration);
     generate(task_proxy, exploration);
 }
 

--- a/src/search/landmarks/landmark_factory_relaxation.cc
+++ b/src/search/landmarks/landmark_factory_relaxation.cc
@@ -1,0 +1,13 @@
+#include "landmark_factory_relaxation.h"
+
+#include "exploration.h"
+
+using namespace std;
+
+namespace landmarks {
+void LandmarkFactoryRelaxation::generate_landmarks(const std::shared_ptr<AbstractTask>& task) {
+    TaskProxy task_proxy(*task);
+    Exploration exploration(task_proxy);
+    generate_landmarks(task, exploration);
+}
+}

--- a/src/search/landmarks/landmark_factory_relaxation.cc
+++ b/src/search/landmarks/landmark_factory_relaxation.cc
@@ -9,5 +9,190 @@ void LandmarkFactoryRelaxation::generate_landmarks(const std::shared_ptr<Abstrac
     TaskProxy task_proxy(*task);
     Exploration exploration(task_proxy);
     generate_landmarks(task, exploration);
+    generate(task_proxy, exploration);
 }
+
+void LandmarkFactoryRelaxation::generate(const TaskProxy &task_proxy, Exploration &exploration) {
+    if (only_causal_landmarks)
+        discard_noncausal_landmarks(task_proxy, exploration);
+    if (!disjunctive_landmarks)
+        discard_disjunctive_landmarks();
+    if (!conjunctive_landmarks)
+        discard_conjunctive_landmarks();
+    lm_graph->set_landmark_ids();
+
+    if (no_orders)
+        discard_all_orderings();
+    else if (reasonable_orders) {
+        utils::g_log << "approx. reasonable orders" << endl;
+        approximate_reasonable_orders(task_proxy, false);
+        utils::g_log << "approx. obedient reasonable orders" << endl;
+        approximate_reasonable_orders(task_proxy, true);
+    }
+    mk_acyclic_graph();
+    lm_graph->set_landmark_cost(calculate_lms_cost());
+    calc_achievers(task_proxy, exploration);
+}
+
+void LandmarkFactoryRelaxation::discard_noncausal_landmarks(
+    const TaskProxy &task_proxy, Exploration &exploration) {
+    int num_all_landmarks = lm_graph->number_of_landmarks();
+    lm_graph->remove_node_if(
+        [this, &task_proxy, &exploration](const LandmarkNode &node) {
+            return !is_causal_landmark(task_proxy, exploration, node);
+        });
+    int num_causal_landmarks = lm_graph->number_of_landmarks();
+    utils::g_log << "Discarded " << num_all_landmarks - num_causal_landmarks
+                 << " non-causal landmarks" << endl;
+}
+
+bool LandmarkFactoryRelaxation::is_causal_landmark(
+    const TaskProxy &task_proxy, Exploration &exploration,
+    const LandmarkNode &landmark) const {
+    /* Test whether the relaxed planning task is unsolvable without using any operator
+       that has "landmark" as a precondition.
+       Similar to "relaxed_task_solvable" above.
+     */
+
+    if (landmark.in_goal)
+        return true;
+    vector<vector<int>> lvl_var;
+    vector<utils::HashMap<FactPair, int>> lvl_op;
+    // Initialize lvl_var to numeric_limits<int>::max()
+    VariablesProxy variables = task_proxy.get_variables();
+    lvl_var.resize(variables.size());
+    for (VariableProxy var : variables) {
+        lvl_var[var.get_id()].resize(var.get_domain_size(),
+                                     numeric_limits<int>::max());
+    }
+    unordered_set<int> exclude_op_ids;
+    vector<FactPair> exclude_props;
+    for (OperatorProxy op : task_proxy.get_operators()) {
+        if (is_landmark_precondition(op, &landmark)) {
+            exclude_op_ids.insert(op.get_id());
+        }
+    }
+    // Do relaxed exploration
+    exploration.compute_reachability_with_excludes(
+        lvl_var, lvl_op, true, exclude_props, exclude_op_ids, false);
+
+    // Test whether all goal propositions have a level of less than numeric_limits<int>::max()
+    for (FactProxy goal : task_proxy.get_goals())
+        if (lvl_var[goal.get_variable().get_id()][goal.get_value()] ==
+            numeric_limits<int>::max())
+            return true;
+
+    return false;
+}
+
+void LandmarkFactoryRelaxation::calc_achievers(const TaskProxy &task_proxy, Exploration &exploration) {
+    VariablesProxy variables = task_proxy.get_variables();
+    for (auto &lmn : lm_graph->get_nodes()) {
+        for (const FactPair &lm_fact : lmn->facts) {
+            const vector<int> &ops = lm_graph->get_operators_including_eff(lm_fact);
+            lmn->possible_achievers.insert(ops.begin(), ops.end());
+
+            if (variables[lm_fact.var].is_derived())
+                lmn->is_derived = true;
+        }
+
+        vector<vector<int>> lvl_var;
+        vector<utils::HashMap<FactPair, int>> lvl_op;
+        relaxed_task_solvable(task_proxy, exploration, lvl_var, lvl_op, true, lmn.get());
+
+        for (int op_or_axom_id : lmn->possible_achievers) {
+            OperatorProxy op = get_operator_or_axiom(task_proxy, op_or_axom_id);
+
+            if (_possibly_reaches_lm(op, lvl_var, lmn.get())) {
+                lmn->first_achievers.insert(op_or_axom_id);
+            }
+        }
+    }
+}
+
+bool LandmarkFactoryRelaxation::relaxed_task_solvable(
+    const TaskProxy &task_proxy, Exploration &exploration, bool level_out,
+    const LandmarkNode *exclude, bool compute_lvl_op) const {
+    std::vector<std::vector<int>> lvl_var;
+    std::vector<utils::HashMap<FactPair, int>> lvl_op;
+    return relaxed_task_solvable(task_proxy, exploration, lvl_var, lvl_op, level_out, exclude, compute_lvl_op);
+}
+
+bool LandmarkFactoryRelaxation::relaxed_task_solvable(
+    const TaskProxy &task_proxy, Exploration &exploration,
+    vector<vector<int>> &lvl_var, vector<utils::HashMap<FactPair, int>> &lvl_op,
+    bool level_out, const LandmarkNode *exclude, bool compute_lvl_op) const {
+    /* Test whether the relaxed planning task is solvable without achieving the propositions in
+     "exclude" (do not apply operators that would add a proposition from "exclude").
+     As a side effect, collect in lvl_var and lvl_op the earliest possible point in time
+     when a proposition / operator can be achieved / become applicable in the relaxed task.
+     */
+
+    OperatorsProxy operators = task_proxy.get_operators();
+    AxiomsProxy axioms = task_proxy.get_axioms();
+    // Initialize lvl_op and lvl_var to numeric_limits<int>::max()
+    if (compute_lvl_op) {
+        lvl_op.resize(operators.size() + axioms.size());
+        for (OperatorProxy op : operators) {
+            add_operator_and_propositions_to_list(op, lvl_op);
+        }
+        for (OperatorProxy axiom : axioms) {
+            add_operator_and_propositions_to_list(axiom, lvl_op);
+        }
+    }
+    VariablesProxy variables = task_proxy.get_variables();
+    lvl_var.resize(variables.size());
+    for (VariableProxy var : variables) {
+        lvl_var[var.get_id()].resize(var.get_domain_size(),
+                                     numeric_limits<int>::max());
+    }
+    // Extract propositions from "exclude"
+    unordered_set<int> exclude_op_ids;
+    vector<FactPair> exclude_props;
+    if (exclude) {
+        for (OperatorProxy op : operators) {
+            if (achieves_non_conditional(op, exclude))
+                exclude_op_ids.insert(op.get_id());
+        }
+        exclude_props.insert(exclude_props.end(),
+                             exclude->facts.begin(), exclude->facts.end());
+    }
+    // Do relaxed exploration
+    exploration.compute_reachability_with_excludes(
+        lvl_var, lvl_op, level_out, exclude_props, exclude_op_ids, compute_lvl_op);
+
+    // Test whether all goal propositions have a level of less than numeric_limits<int>::max()
+    for (FactProxy goal : task_proxy.get_goals())
+        if (lvl_var[goal.get_variable().get_id()][goal.get_value()] ==
+            numeric_limits<int>::max())
+            return false;
+
+    return true;
+}
+
+bool LandmarkFactoryRelaxation::achieves_non_conditional(
+    const OperatorProxy &o, const LandmarkNode *lmp) const {
+    /* Test whether the landmark is achieved by the operator unconditionally.
+    A disjunctive landmark is achieved if one of its disjuncts is achieved. */
+    assert(lmp);
+    for (EffectProxy effect: o.get_effects()) {
+        for (const FactPair &lm_fact : lmp->facts) {
+            FactProxy effect_fact = effect.get_fact();
+            if (effect_fact.get_pair() == lm_fact) {
+                if (effect.get_conditions().empty())
+                    return true;
+            }
+        }
+    }
+    return false;
+}
+
+void LandmarkFactoryRelaxation::add_operator_and_propositions_to_list(
+    const OperatorProxy &op, vector<utils::HashMap<FactPair, int>> &lvl_op) const {
+    int op_or_axiom_id = get_operator_or_axiom_id(op);
+    for (EffectProxy effect : op.get_effects()) {
+        lvl_op[op_or_axiom_id].emplace(effect.get_fact().get_pair(), numeric_limits<int>::max());
+    }
+}
+
 }

--- a/src/search/landmarks/landmark_factory_relaxation.h
+++ b/src/search/landmarks/landmark_factory_relaxation.h
@@ -4,15 +4,43 @@
 #include "landmark_factory.h"
 
 namespace landmarks {
+class Exploration;
+
 class LandmarkFactoryRelaxation : public LandmarkFactory {
 protected:
     explicit LandmarkFactoryRelaxation(const options::Options &opts)
         : LandmarkFactory(opts) {}
 
+    bool relaxed_task_solvable(const TaskProxy &task_proxy, Exploration &exploration,
+                               bool level_out,
+                               const LandmarkNode *exclude,
+                               bool compute_lvl_op = false) const;
+    bool relaxed_task_solvable(const TaskProxy &task_proxy, Exploration &exploration,
+                               std::vector<std::vector<int>> &lvl_var,
+                               std::vector<utils::HashMap<FactPair, int>> &lvl_op,
+                               bool level_out,
+                               const LandmarkNode *exclude,
+                               bool compute_lvl_op = false) const;
+
 private:
     void generate_landmarks(const std::shared_ptr<AbstractTask> &task) override;
 
-    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task, Exploration &exploration) = 0;
+    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task,
+                                    Exploration &exploration) = 0;
+    void generate(const TaskProxy &task_proxy, Exploration &exploration);
+
+    void discard_noncausal_landmarks(const TaskProxy &task_proxy,
+                                     Exploration &exploration);
+    bool is_causal_landmark(const TaskProxy &task_proxy,
+                            Exploration &exploration,
+                            const LandmarkNode &landmark) const;
+
+    void calc_achievers(const TaskProxy &task_proxy, Exploration &exploration);
+    bool achieves_non_conditional(const OperatorProxy &o,
+                                  const LandmarkNode *lmp) const;
+    void add_operator_and_propositions_to_list(
+        const OperatorProxy &op, std::vector<utils::HashMap<FactPair, int>> &lvl_op) const;
+
 };
 }
 

--- a/src/search/landmarks/landmark_factory_relaxation.h
+++ b/src/search/landmarks/landmark_factory_relaxation.h
@@ -1,0 +1,19 @@
+#ifndef LANDMARKS_LANDMARK_FACTORY_RELAXATION_H
+#define LANDMARKS_LANDMARK_FACTORY_RELAXATION_H
+
+#include "landmark_factory.h"
+
+namespace landmarks {
+class LandmarkFactoryRelaxation : public LandmarkFactory {
+protected:
+    explicit LandmarkFactoryRelaxation(const options::Options &opts)
+        : LandmarkFactory(opts) {}
+
+private:
+    void generate_landmarks(const std::shared_ptr<AbstractTask> &task) override;
+
+    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task, Exploration &exploration) = 0;
+};
+}
+
+#endif

--- a/src/search/landmarks/landmark_factory_relaxation.h
+++ b/src/search/landmarks/landmark_factory_relaxation.h
@@ -25,12 +25,14 @@ protected:
 private:
     void generate_landmarks(const std::shared_ptr<AbstractTask> &task) override;
 
-    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task,
-                                    Exploration &exploration) = 0;
+    virtual void generate_relaxed_landmarks(const std::shared_ptr<AbstractTask> &task,
+                                            Exploration &exploration) = 0;
     void generate(const TaskProxy &task_proxy, Exploration &exploration);
 
+    // TODO: this is duplicated here and in LandmarkFactoryHM
     void discard_noncausal_landmarks(const TaskProxy &task_proxy,
                                      Exploration &exploration);
+    // TODO: this is duplicated here and in LandmarkFactoryHM
     bool is_causal_landmark(const TaskProxy &task_proxy,
                             Exploration &exploration,
                             const LandmarkNode &landmark) const;
@@ -40,7 +42,6 @@ private:
                                   const LandmarkNode *lmp) const;
     void add_operator_and_propositions_to_list(
         const OperatorProxy &op, std::vector<utils::HashMap<FactPair, int>> &lvl_op) const;
-
 };
 }
 

--- a/src/search/landmarks/landmark_factory_rpg_exhaust.cc
+++ b/src/search/landmarks/landmark_factory_rpg_exhaust.cc
@@ -17,7 +17,7 @@ namespace landmarks {
    method with others, don't use it by itself. */
 
 LandmarkFactoryRpgExhaust::LandmarkFactoryRpgExhaust(const Options &opts)
-    : LandmarkFactory(opts) {
+    : LandmarkFactoryRelaxation(opts) {
 }
 
 void LandmarkFactoryRpgExhaust::generate_landmarks(

--- a/src/search/landmarks/landmark_factory_rpg_exhaust.cc
+++ b/src/search/landmarks/landmark_factory_rpg_exhaust.cc
@@ -20,7 +20,7 @@ LandmarkFactoryRpgExhaust::LandmarkFactoryRpgExhaust(const Options &opts)
     : LandmarkFactoryRelaxation(opts) {
 }
 
-void LandmarkFactoryRpgExhaust::generate_landmarks(
+void LandmarkFactoryRpgExhaust::generate_relaxed_landmarks(
     const shared_ptr<AbstractTask> &task, Exploration &exploration) {
     TaskProxy task_proxy(*task);
     utils::g_log << "Generating landmarks by testing all facts with RPG method" << endl;

--- a/src/search/landmarks/landmark_factory_rpg_exhaust.h
+++ b/src/search/landmarks/landmark_factory_rpg_exhaust.h
@@ -5,8 +5,8 @@
 
 namespace landmarks {
 class LandmarkFactoryRpgExhaust : public LandmarkFactoryRelaxation {
-    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task,
-                                    Exploration &exploration) override;
+    virtual void generate_relaxed_landmarks(const std::shared_ptr<AbstractTask> &task,
+                                            Exploration &exploration) override;
 
 public:
     explicit LandmarkFactoryRpgExhaust(const options::Options &opts);

--- a/src/search/landmarks/landmark_factory_rpg_exhaust.h
+++ b/src/search/landmarks/landmark_factory_rpg_exhaust.h
@@ -1,10 +1,10 @@
 #ifndef LANDMARKS_LANDMARK_FACTORY_RPG_EXHAUST_H
 #define LANDMARKS_LANDMARK_FACTORY_RPG_EXHAUST_H
 
-#include "landmark_factory.h"
+#include "landmark_factory_relaxation.h"
 
 namespace landmarks {
-class LandmarkFactoryRpgExhaust : public LandmarkFactory {
+class LandmarkFactoryRpgExhaust : public LandmarkFactoryRelaxation {
     virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task,
                                     Exploration &exploration) override;
 

--- a/src/search/landmarks/landmark_factory_rpg_sasp.cc
+++ b/src/search/landmarks/landmark_factory_rpg_sasp.cc
@@ -411,7 +411,7 @@ void LandmarkFactoryRpgSasp::compute_disjunctive_preconditions(
     }
 }
 
-void LandmarkFactoryRpgSasp::generate_landmarks(
+void LandmarkFactoryRpgSasp::generate_relaxed_landmarks(
     const shared_ptr<AbstractTask> &task, Exploration &exploration) {
     TaskProxy task_proxy(*task);
     utils::g_log << "Generating landmarks using the RPG/SAS+ approach\n";

--- a/src/search/landmarks/landmark_factory_rpg_sasp.cc
+++ b/src/search/landmarks/landmark_factory_rpg_sasp.cc
@@ -18,7 +18,7 @@ using utils::ExitCode;
 
 namespace landmarks {
 LandmarkFactoryRpgSasp::LandmarkFactoryRpgSasp(const Options &opts)
-    : LandmarkFactory(opts) {
+    : LandmarkFactoryRelaxation(opts) {
 }
 
 void LandmarkFactoryRpgSasp::build_dtg_successors(const TaskProxy &task_proxy) {

--- a/src/search/landmarks/landmark_factory_rpg_sasp.cc
+++ b/src/search/landmarks/landmark_factory_rpg_sasp.cc
@@ -437,7 +437,7 @@ void LandmarkFactoryRpgSasp::generate_landmarks(
             // applied (in lvl_ops).
             vector<vector<int>> lvl_var;
             vector<utils::HashMap<FactPair, int>> lvl_op;
-            compute_predecessor_information(task_proxy, exploration, bp, lvl_var, lvl_op);
+            relaxed_task_solvable(task_proxy, exploration, lvl_var, lvl_op, true, bp);
             // Use this information to determine all operators that can possibly achieve bp
             // for the first time, and collect any precondition propositions that all such
             // operators share (if there are any).

--- a/src/search/landmarks/landmark_factory_rpg_sasp.h
+++ b/src/search/landmarks/landmark_factory_rpg_sasp.h
@@ -1,14 +1,14 @@
 #ifndef LANDMARKS_LANDMARK_FACTORY_RPG_SASP_H
 #define LANDMARKS_LANDMARK_FACTORY_RPG_SASP_H
 
-#include "landmark_factory.h"
+#include "landmark_factory_relaxation.h"
 
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 namespace landmarks {
-class LandmarkFactoryRpgSasp : public LandmarkFactory {
+class LandmarkFactoryRpgSasp : public LandmarkFactoryRelaxation {
     std::list<LandmarkNode *> open_landmarks;
     std::vector<std::vector<int>> disjunction_classes;
 

--- a/src/search/landmarks/landmark_factory_rpg_sasp.h
+++ b/src/search/landmarks/landmark_factory_rpg_sasp.h
@@ -39,8 +39,9 @@ class LandmarkFactoryRpgSasp : public LandmarkFactoryRelaxation {
     int min_cost_for_landmark(const TaskProxy &task_proxy,
                               LandmarkNode *bp,
                               std::vector<std::vector<int>> &lvl_var);
-    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task,
-                                    Exploration &exploration) override;
+    virtual void generate_relaxed_landmarks(
+        const std::shared_ptr<AbstractTask> &task,
+        Exploration &exploration) override;
     void found_simple_lm_and_order(const FactPair &a, LandmarkNode &b,
                                    EdgeType t);
     void found_disj_lm_and_order(const TaskProxy &task_proxy,

--- a/src/search/landmarks/landmark_factory_zhu_givan.cc
+++ b/src/search/landmarks/landmark_factory_zhu_givan.cc
@@ -18,7 +18,7 @@ using namespace std;
 
 namespace landmarks {
 LandmarkFactoryZhuGivan::LandmarkFactoryZhuGivan(const Options &opts)
-    : LandmarkFactory(opts) {
+    : LandmarkFactoryRelaxation(opts) {
 }
 
 void LandmarkFactoryZhuGivan::generate_landmarks(

--- a/src/search/landmarks/landmark_factory_zhu_givan.cc
+++ b/src/search/landmarks/landmark_factory_zhu_givan.cc
@@ -21,7 +21,7 @@ LandmarkFactoryZhuGivan::LandmarkFactoryZhuGivan(const Options &opts)
     : LandmarkFactoryRelaxation(opts) {
 }
 
-void LandmarkFactoryZhuGivan::generate_landmarks(
+void LandmarkFactoryZhuGivan::generate_relaxed_landmarks(
     const shared_ptr<AbstractTask> &task, Exploration &exploration) {
     TaskProxy task_proxy(*task);
     utils::g_log << "Generating landmarks using Zhu/Givan label propagation\n";

--- a/src/search/landmarks/landmark_factory_zhu_givan.h
+++ b/src/search/landmarks/landmark_factory_zhu_givan.h
@@ -71,8 +71,9 @@ public:
     // Link operators to its propositions in trigger list.
     void add_operator_to_triggers(const OperatorProxy &op);
 
-    virtual void generate_landmarks(const std::shared_ptr<AbstractTask> &task,
-                                    Exploration &exploration) override;
+    virtual void generate_relaxed_landmarks(
+        const std::shared_ptr<AbstractTask> &task,
+        Exploration &exploration) override;
 
 public:
     explicit LandmarkFactoryZhuGivan(const options::Options &opts);

--- a/src/search/landmarks/landmark_factory_zhu_givan.h
+++ b/src/search/landmarks/landmark_factory_zhu_givan.h
@@ -1,7 +1,7 @@
 #ifndef LANDMARKS_LANDMARK_FACTORY_ZHU_GIVAN_H
 #define LANDMARKS_LANDMARK_FACTORY_ZHU_GIVAN_H
 
-#include "landmark_factory.h"
+#include "landmark_factory_relaxation.h"
 
 #include "../utils/hash.h"
 
@@ -12,7 +12,7 @@
 namespace landmarks {
 using lm_set = utils::HashSet<FactPair>;
 
-class LandmarkFactoryZhuGivan : public LandmarkFactory {
+class LandmarkFactoryZhuGivan : public LandmarkFactoryRelaxation {
     class plan_graph_node {
 public:
         lm_set labels;


### PR DESCRIPTION
As discussed, I have moved everything that uses the Exploration object to the subclasses of LandmarkFactory. This pull request is  to give you an idea what has happened so far.

I tried to achieve moving the Exploration object without making any functional changes. The only functional change I made is in commit 69694b4 where I removed the Exploration object from the LandmarkFactoryMerged by keeping information from the individual landmark graphs instead of recomputing them. The only difference this makes is that hm achievers are now computed with the calc_achievers implementation in LandmarkFactoryHM also when embedded into a LandmarkFactoryMerged, whereas this was "overwritten" with calc_achievers of LandmarkFactory before (in the case of embedding hm into a merged lm factory). I ran an experiment that shows that this does not affect behavior:

https://ai.dmi.unibas.ch/_tmp_files/tkeller/issue990-2021-01-25-B-optimal.html

I also ran an experiment for a satisficing configuration and nothing changed so far:

https://ai.dmi.unibas.ch/_tmp_files/tkeller/issue990-2021-01-25-A-satisficing.html


