### PR TITLE
Improve errors

### DIFF
--- a/src/translate/pddl_parser/parsing_functions.py
+++ b/src/translate/pddl_parser/parsing_functions.py
@@ -61,6 +61,8 @@ def parse_condition(alist, type_dict, predicate_dict):
 
 def parse_condition_aux(alist, negated, type_dict, predicate_dict):
     """Parse a PDDL condition. The condition is translated into NNF on the fly."""
+    if len(alist) == 0:
+        raise RuntimeError("Empty condition expression")
     tag = alist[0]
     if tag in ("and", "or", "not", "imply"):
         args = alist[1:]

--- a/src/translate/pddl_parser/parsing_functions.py
+++ b/src/translate/pddl_parser/parsing_functions.py
@@ -317,7 +317,7 @@ def parse_domain_pddl(domain_pddl):
     iterator = iter(domain_pddl)
 
     define_tag = next(iterator)
-    assert define_tag == "define"
+    assert define_tag == "define", "define_tag = \"%s\" instead of \"define\"" % define_tag
     domain_line = next(iterator)
     assert domain_line[0] == "domain" and len(domain_line) == 2
     yield domain_line[1]


### PR DESCRIPTION
Slightly better error messages for some corner cases:
- when PDDL does not start with `(define `
- when a condition is empty (`()`)