### PR TITLE
Add -Wmissing-declarations flag to detect global functions not declared in header files.

### DIFF
--- a/src/cmake_modules/FastDownwardMacros.cmake
+++ b/src/cmake_modules/FastDownwardMacros.cmake
@@ -18,7 +18,7 @@ macro(fast_downward_set_compiler_flags)
         check_and_set_compiler_flag( "-std=c++20" )
 
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wnon-virtual-dtor -Wfloat-conversion")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Wfloat-conversion -Wmissing-declarations")
 
         if (CMAKE_COMPILER_IS_GNUCXX
             AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12

--- a/src/search/algorithms/sccs.cc
+++ b/src/search/algorithms/sccs.cc
@@ -5,7 +5,7 @@
 using namespace std;
 
 namespace sccs {
-void dfs(
+static void dfs(
     const vector<vector<int>> &graph,
     int vertex,
     vector<int> &dfs_numbers,

--- a/src/search/landmarks/util.cc
+++ b/src/search/landmarks/util.cc
@@ -11,7 +11,7 @@
 using namespace std;
 
 namespace landmarks {
-bool _possibly_fires(const EffectConditionsProxy &conditions, const vector<vector<bool>> &reached) {
+static bool _possibly_fires(const EffectConditionsProxy &conditions, const vector<vector<bool>> &reached) {
     for (FactProxy cond : conditions)
         if (!reached[cond.get_variable().get_id()][cond.get_value()])
             return false;

--- a/src/search/lp/cplex_solver_interface.cc
+++ b/src/search/lp/cplex_solver_interface.cc
@@ -55,7 +55,7 @@ static void CPX_CALL(Func cpxfunc, CPXENVptr env, Args && ... args) {
     }
 }
 
-CPXLPptr createProblem(CPXENVptr env, const string &name) {
+static CPXLPptr createProblem(CPXENVptr env, const string &name) {
     int status = 0;
     CPXLPptr problem = CPXcreateprob(env, &status, name.c_str());
     if (status) {
@@ -64,7 +64,7 @@ CPXLPptr createProblem(CPXENVptr env, const string &name) {
     return problem;
 }
 
-void freeProblem(CPXENVptr env, CPXLPptr *problem) {
+static void freeProblem(CPXENVptr env, CPXLPptr *problem) {
     CPX_CALL(CPXfreeprob, env, problem);
 }
 

--- a/src/search/merge_and_shrink/merge_scoring_function_miasm_utils.cc
+++ b/src/search/merge_and_shrink/merge_scoring_function_miasm_utils.cc
@@ -21,7 +21,7 @@ namespace merge_and_shrink {
   copy the transition system, apply the state equivalence relation to it and
   return the result. Return nullptr otherwise.
 */
-unique_ptr<TransitionSystem> copy_and_shrink_ts(
+static unique_ptr<TransitionSystem> copy_and_shrink_ts(
     const TransitionSystem &ts,
     const Distances &distances,
     const ShrinkStrategy &shrink_strategy,

--- a/src/search/merge_and_shrink/merge_strategy_factory_sccs.cc
+++ b/src/search/merge_and_shrink/merge_strategy_factory_sccs.cc
@@ -21,11 +21,11 @@
 using namespace std;
 
 namespace merge_and_shrink {
-bool compare_sccs_increasing(const vector<int> &lhs, const vector<int> &rhs) {
+static bool compare_sccs_increasing(const vector<int> &lhs, const vector<int> &rhs) {
     return lhs.size() < rhs.size();
 }
 
-bool compare_sccs_decreasing(const vector<int> &lhs, const vector<int> &rhs) {
+static bool compare_sccs_decreasing(const vector<int> &lhs, const vector<int> &rhs) {
     return lhs.size() > rhs.size();
 }
 

--- a/src/search/merge_and_shrink/transition_system.cc
+++ b/src/search/merge_and_shrink/transition_system.cc
@@ -10,7 +10,6 @@
 #include <cassert>
 #include <iostream>
 #include <set>
-#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -19,6 +18,11 @@ using namespace std;
 using utils::ExitCode;
 
 namespace merge_and_shrink {
+ostream &operator<<(ostream &os, const Transition &trans) {
+    os << trans.src << "->" << trans.target;
+    return os;
+}
+
 void LocalLabelInfo::add_label(int label, int label_cost) {
     label_group.push_back(label);
     if (label_cost != -1) {

--- a/src/search/merge_and_shrink/transition_system.cc
+++ b/src/search/merge_and_shrink/transition_system.cc
@@ -19,11 +19,6 @@ using namespace std;
 using utils::ExitCode;
 
 namespace merge_and_shrink {
-ostream &operator<<(ostream &os, const Transition &trans) {
-    os << trans.src << "->" << trans.target;
-    return os;
-}
-
 void LocalLabelInfo::add_label(int label, int label_cost) {
     label_group.push_back(label);
     if (label_cost != -1) {

--- a/src/search/merge_and_shrink/transition_system.h
+++ b/src/search/merge_and_shrink/transition_system.h
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -40,6 +41,8 @@ struct Transition {
         return !(*this < other);
     }
 };
+
+std::ostream &operator<<(std::ostream &os, const Transition &trans);
 
 using LabelGroup = std::vector<int>;
 

--- a/src/search/merge_and_shrink/utils.cc
+++ b/src/search/merge_and_shrink/utils.cc
@@ -61,7 +61,7 @@ pair<int, int> compute_shrink_sizes(
   if the size limit is not violated. If so, trigger the shrinking process.
   Return true iff the factor was actually shrunk.
 */
-bool shrink_factor(
+static bool shrink_factor(
     FactoredTransitionSystem &fts,
     int index,
     int new_size,

--- a/src/search/operator_counting/delete_relaxation_constraints.cc
+++ b/src/search/operator_counting/delete_relaxation_constraints.cc
@@ -11,7 +11,7 @@
 using namespace std;
 
 namespace operator_counting {
-void add_lp_variables(int count, LPVariables &variables, vector<int> &indices,
+static void add_lp_variables(int count, LPVariables &variables, vector<int> &indices,
                       double lower, double upper, double objective,
                       bool is_integer) {
     for (int i = 0; i < count; ++i) {

--- a/src/search/operator_counting/delete_relaxation_constraints.cc
+++ b/src/search/operator_counting/delete_relaxation_constraints.cc
@@ -12,8 +12,8 @@ using namespace std;
 
 namespace operator_counting {
 static void add_lp_variables(int count, LPVariables &variables, vector<int> &indices,
-                      double lower, double upper, double objective,
-                      bool is_integer) {
+                             double lower, double upper, double objective,
+                             bool is_integer) {
     for (int i = 0; i < count; ++i) {
         indices.push_back(variables.size());
         variables.emplace_back(lower, upper, objective, is_integer);

--- a/src/search/operator_counting/state_equation_constraints.cc
+++ b/src/search/operator_counting/state_equation_constraints.cc
@@ -16,7 +16,7 @@ StateEquationConstraints::StateEquationConstraints(
     : log(utils::get_log_from_options(opts)) {
 }
 
-void add_indices_to_constraint(lp::LPConstraint &constraint,
+static void add_indices_to_constraint(lp::LPConstraint &constraint,
                                const set<int> &indices,
                                double coefficient) {
     for (int index : indices) {

--- a/src/search/operator_counting/state_equation_constraints.cc
+++ b/src/search/operator_counting/state_equation_constraints.cc
@@ -17,8 +17,8 @@ StateEquationConstraints::StateEquationConstraints(
 }
 
 static void add_indices_to_constraint(lp::LPConstraint &constraint,
-                               const set<int> &indices,
-                               double coefficient) {
+                                      const set<int> &indices,
+                                      double coefficient) {
     for (int index : indices) {
         constraint.insert(index, coefficient);
     }

--- a/src/search/pdbs/canonical_pdbs_heuristic.cc
+++ b/src/search/pdbs/canonical_pdbs_heuristic.cc
@@ -15,7 +15,7 @@
 using namespace std;
 
 namespace pdbs {
-CanonicalPDBs get_canonical_pdbs_from_options(
+static CanonicalPDBs get_canonical_pdbs_from_options(
     const shared_ptr<AbstractTask> &task, const plugins::Options &opts, utils::LogProxy &log) {
     shared_ptr<PatternCollectionGenerator> pattern_generator =
         opts.get<shared_ptr<PatternCollectionGenerator>>("patterns");

--- a/src/search/pdbs/cegar.cc
+++ b/src/search/pdbs/cegar.cc
@@ -274,7 +274,7 @@ void CEGAR::compute_initial_collection() {
   potentially not applicable in the state, and expecting that the operator
   has not conditional effects.
 */
-void apply_op_to_state(vector<int> &state, const OperatorProxy &op) {
+static void apply_op_to_state(vector<int> &state, const OperatorProxy &op) {
     assert(!op.is_axiom());
     for (EffectProxy effect : op.get_effects()) {
         assert(effect.get_conditions().empty());

--- a/src/search/pdbs/pattern_collection_generator_hillclimbing.cc
+++ b/src/search/pdbs/pattern_collection_generator_hillclimbing.cc
@@ -459,7 +459,7 @@ PatternCollectionInformation PatternCollectionGeneratorHillclimbing::compute_pat
     return current_pdbs->get_pattern_collection_information(log);
 }
 
-void add_hillclimbing_options(plugins::Feature &feature) {
+static void add_hillclimbing_options(plugins::Feature &feature) {
     feature.document_note(
         "Note",
         "The pattern collection created by the algorithm will always contain "
@@ -555,7 +555,7 @@ void add_hillclimbing_options(plugins::Feature &feature) {
     add_generator_options_to_feature(feature);
 }
 
-void check_hillclimbing_options(
+static void check_hillclimbing_options(
     const plugins::Options &opts, const utils::Context &context) {
     if (opts.get<int>("min_improvement") > opts.get<int>("num_samples")) {
         context.error(

--- a/src/search/pdbs/pdb_heuristic.cc
+++ b/src/search/pdbs/pdb_heuristic.cc
@@ -11,7 +11,7 @@
 using namespace std;
 
 namespace pdbs {
-shared_ptr<PatternDatabase> get_pdb_from_options(const shared_ptr<AbstractTask> &task,
+static shared_ptr<PatternDatabase> get_pdb_from_options(const shared_ptr<AbstractTask> &task,
                                                  const plugins::Options &opts) {
     shared_ptr<PatternGenerator> pattern_generator =
         opts.get<shared_ptr<PatternGenerator>>("pattern");

--- a/src/search/pdbs/pdb_heuristic.cc
+++ b/src/search/pdbs/pdb_heuristic.cc
@@ -12,7 +12,7 @@ using namespace std;
 
 namespace pdbs {
 static shared_ptr<PatternDatabase> get_pdb_from_options(const shared_ptr<AbstractTask> &task,
-                                                 const plugins::Options &opts) {
+                                                        const plugins::Options &opts) {
     shared_ptr<PatternGenerator> pattern_generator =
         opts.get<shared_ptr<PatternGenerator>>("pattern");
     PatternInformation pattern_info = pattern_generator->generate(task);

--- a/src/search/pdbs/zero_one_pdbs_heuristic.cc
+++ b/src/search/pdbs/zero_one_pdbs_heuristic.cc
@@ -9,7 +9,7 @@
 using namespace std;
 
 namespace pdbs {
-ZeroOnePDBs get_zero_one_pdbs_from_options(
+static ZeroOnePDBs get_zero_one_pdbs_from_options(
     const shared_ptr<AbstractTask> &task, const plugins::Options &opts) {
     shared_ptr<PatternCollectionGenerator> pattern_generator =
         opts.get<shared_ptr<PatternCollectionGenerator>>("patterns");

--- a/src/search/search_algorithm.cc
+++ b/src/search/search_algorithm.cc
@@ -22,7 +22,7 @@ using utils::ExitCode;
 
 class PruningMethod;
 
-successor_generator::SuccessorGenerator &get_successor_generator(
+static successor_generator::SuccessorGenerator &get_successor_generator(
     const TaskProxy &task_proxy, utils::LogProxy &log) {
     log << "Building successor generator..." << flush;
     int peak_memory_before = utils::get_peak_memory_in_kb();

--- a/src/search/tasks/root_task.cc
+++ b/src/search/tasks/root_task.cc
@@ -133,7 +133,7 @@ static void check_facts(const ExplicitOperator &action, const vector<ExplicitVar
     }
 }
 
-void check_magic(istream &in, const string &magic) {
+static void check_magic(istream &in, const string &magic) {
     string word;
     in >> word;
     if (word != magic) {
@@ -148,7 +148,7 @@ void check_magic(istream &in, const string &magic) {
     }
 }
 
-vector<FactPair> read_facts(istream &in) {
+static vector<FactPair> read_facts(istream &in) {
     int count;
     in >> count;
     vector<FactPair> conditions;
@@ -218,7 +218,7 @@ ExplicitOperator::ExplicitOperator(istream &in, bool is_an_axiom, bool use_metri
     assert(cost >= 0);
 }
 
-void read_and_verify_version(istream &in) {
+static void read_and_verify_version(istream &in) {
     int version;
     check_magic(in, "begin_version");
     in >> version;
@@ -231,7 +231,7 @@ void read_and_verify_version(istream &in) {
     }
 }
 
-bool read_metric(istream &in) {
+static bool read_metric(istream &in) {
     bool use_metric;
     check_magic(in, "begin_metric");
     in >> use_metric;
@@ -239,7 +239,7 @@ bool read_metric(istream &in) {
     return use_metric;
 }
 
-vector<ExplicitVariable> read_variables(istream &in) {
+static vector<ExplicitVariable> read_variables(istream &in) {
     int count;
     in >> count;
     vector<ExplicitVariable> variables;
@@ -250,7 +250,7 @@ vector<ExplicitVariable> read_variables(istream &in) {
     return variables;
 }
 
-vector<vector<set<FactPair>>> read_mutexes(istream &in, const vector<ExplicitVariable> &variables) {
+static vector<vector<set<FactPair>>> read_mutexes(istream &in, const vector<ExplicitVariable> &variables) {
     vector<vector<set<FactPair>>> inconsistent_facts(variables.size());
     for (size_t i = 0; i < variables.size(); ++i)
         inconsistent_facts[i].resize(variables[i].domain_size);
@@ -299,7 +299,7 @@ vector<vector<set<FactPair>>> read_mutexes(istream &in, const vector<ExplicitVar
     return inconsistent_facts;
 }
 
-vector<FactPair> read_goal(istream &in) {
+static vector<FactPair> read_goal(istream &in) {
     check_magic(in, "begin_goal");
     vector<FactPair> goals = read_facts(in);
     check_magic(in, "end_goal");
@@ -310,7 +310,7 @@ vector<FactPair> read_goal(istream &in) {
     return goals;
 }
 
-vector<ExplicitOperator> read_actions(
+static vector<ExplicitOperator> read_actions(
     istream &in, bool is_axiom, bool use_metric,
     const vector<ExplicitVariable> &variables) {
     int count;

--- a/src/search/utils/memory.cc
+++ b/src/search/utils/memory.cc
@@ -13,7 +13,7 @@ static char *extra_memory_padding = nullptr;
 // Save standard out-of-memory handler.
 static void (*standard_out_of_memory_handler)() = nullptr;
 
-void continuing_out_of_memory_handler() {
+static void continuing_out_of_memory_handler() {
     release_extra_memory_padding();
     utils::g_log << "Failed to allocate memory. Released extra memory padding." << endl;
 }

--- a/src/search/utils/system_unix.cc
+++ b/src/search/utils/system_unix.cc
@@ -97,6 +97,7 @@ static void print_peak_memory_reentrant() {
     write_reentrant_str(STDOUT_FILENO, "Peak memory: ");
     write_reentrant_int(STDOUT_FILENO, get_peak_memory_in_kb());
     write_reentrant_str(STDOUT_FILENO, " KB\n");
+    utils::unused_variable(read_char_reentrant);
 #else
 
     int proc_file_descr = TEMP_FAILURE_RETRY(open("/proc/self/status", O_RDONLY));

--- a/src/search/utils/system_unix.cc
+++ b/src/search/utils/system_unix.cc
@@ -42,7 +42,7 @@
 using namespace std;
 
 namespace utils {
-void write_reentrant(int filedescr, const char *message, int len) {
+static void write_reentrant(int filedescr, const char *message, int len) {
     while (len > 0) {
         int written;
         do {
@@ -60,15 +60,15 @@ void write_reentrant(int filedescr, const char *message, int len) {
     }
 }
 
-void write_reentrant_str(int filedescr, const char *message) {
+static void write_reentrant_str(int filedescr, const char *message) {
     write_reentrant(filedescr, message, strlen(message));
 }
 
-void write_reentrant_char(int filedescr, char c) {
+static void write_reentrant_char(int filedescr, char c) {
     write_reentrant(filedescr, &c, 1);
 }
 
-void write_reentrant_int(int filedescr, int value) {
+static void write_reentrant_int(int filedescr, int value) {
     char buffer[32];
     int len = snprintf(buffer, sizeof(buffer), "%d", value);
     if (len < 0)
@@ -76,7 +76,7 @@ void write_reentrant_int(int filedescr, int value) {
     write_reentrant(filedescr, buffer, len);
 }
 
-bool read_char_reentrant(int filedescr, char *c) {
+static bool read_char_reentrant(int filedescr, char *c) {
     int result;
     do {
         result = read(filedescr, c, 1);
@@ -91,7 +91,7 @@ bool read_char_reentrant(int filedescr, char *c) {
     return result == 1;
 }
 
-void print_peak_memory_reentrant() {
+static void print_peak_memory_reentrant() {
 #if OPERATING_SYSTEM == OSX
     // TODO: Write print_peak_memory_reentrant() for OS X.
     write_reentrant_str(STDOUT_FILENO, "Peak memory: ");
@@ -148,14 +148,14 @@ void print_peak_memory_reentrant() {
 }
 
 #if OPERATING_SYSTEM == LINUX
-void exit_handler(int, void *) {
+static void exit_handler(int, void *) {
 #elif OPERATING_SYSTEM == OSX
 void exit_handler() {
 #endif
     print_peak_memory_reentrant();
 }
 
-void out_of_memory_handler() {
+static void out_of_memory_handler() {
     /*
       We do not use any memory padding currently. The methods below should
       only use stack memory. If we ever run into situations where the stack
@@ -166,7 +166,7 @@ void out_of_memory_handler() {
     exit_with(ExitCode::SEARCH_OUT_OF_MEMORY);
 }
 
-void signal_handler(int signal_number) {
+static void signal_handler(int signal_number) {
     print_peak_memory_reentrant();
     write_reentrant_str(STDOUT_FILENO, "caught signal ");
     write_reentrant_int(STDOUT_FILENO, signal_number);


### PR DESCRIPTION
Such functions should usually be declared static, making them invisible to other compilation units.