### PR TITLE
issue1113

### DIFF
--- a/src/search/parser/abstract_syntax_tree.cc
+++ b/src/search/parser/abstract_syntax_tree.cc
@@ -183,6 +183,10 @@ void FunctionCallNode::collect_keyword_arguments(
     DecorateContext &context, CollectedArguments &arguments) const {
     unordered_map<string, plugins::ArgumentInfo> argument_infos_by_key;
     for (const plugins::ArgumentInfo &arg_info : argument_infos) {
+        assert(!argument_infos_by_key.contains(arg_info.key));
+        if (argument_infos_by_key.contains(arg_info.key)){
+            cout << "Already contains " << arg_info.key << endl;
+        }
         argument_infos_by_key.insert({arg_info.key, arg_info});
     }
 

--- a/src/search/parser/abstract_syntax_tree.cc
+++ b/src/search/parser/abstract_syntax_tree.cc
@@ -184,9 +184,6 @@ void FunctionCallNode::collect_keyword_arguments(
     unordered_map<string, plugins::ArgumentInfo> argument_infos_by_key;
     for (const plugins::ArgumentInfo &arg_info : argument_infos) {
         assert(!argument_infos_by_key.contains(arg_info.key));
-        if (argument_infos_by_key.contains(arg_info.key)){
-            cout << "Already contains " << arg_info.key << endl;
-        }
         argument_infos_by_key.insert({arg_info.key, arg_info});
     }
 

--- a/src/search/pdbs/pattern_collection_generator_hillclimbing.cc
+++ b/src/search/pdbs/pattern_collection_generator_hillclimbing.cc
@@ -552,7 +552,6 @@ static void add_hillclimbing_options(plugins::Feature &feature) {
         "infinity",
         plugins::Bounds("0.0", "infinity"));
     utils::add_rng_options(feature);
-    add_generator_options_to_feature(feature);
 }
 
 static void check_hillclimbing_options(
@@ -596,6 +595,7 @@ public:
             "optimized for the Evaluator#Canonical_PDB heuristic. It it described "
             "in the following paper:" + paper_references());
         add_hillclimbing_options(*this);
+        add_generator_options_to_feature(*this);
     }
 
     virtual shared_ptr<PatternCollectionGeneratorHillclimbing> create_component(const plugins::Options &options, const utils::Context &context) const override {

--- a/src/search/plugins/raw_registry.cc
+++ b/src/search/plugins/raw_registry.cc
@@ -178,7 +178,7 @@ Features RawRegistry::collect_features(
             int parameter_occurrence = pair.second;
             if (parameter_occurrence > 1) {
                 errors.push_back(
-                    "The Parameter '" + parameter + "' in '" + feature_key + "' is defined " +
+                    "The parameter '" + parameter + "' in '" + feature_key + "' is defined " +
                     to_string(parameter_occurrence) + " times.");
             }
         }

--- a/src/search/plugins/raw_registry.cc
+++ b/src/search/plugins/raw_registry.cc
@@ -163,23 +163,23 @@ Features RawRegistry::collect_features(
                 "Missing Plugin for type of feature '" + feature_key + "'.");
         }
 
-        unordered_map<string, int> argument_key_occurrences;
+        unordered_map<string, int> parameter_occurrences;
         for (const ArgumentInfo &arg_info : feature.get_arguments()) {
             if (arg_info.type == TypeRegistry::NO_TYPE) {
                 errors.push_back(
-                    "Missing Plugin for type of argument '" + arg_info.key
+                    "Missing Plugin for type of parameter '" + arg_info.key
                     + "' of feature '" + feature_key + "'.");
             }
-            ++argument_key_occurrences[arg_info.key];
+            ++parameter_occurrences[arg_info.key];
         }
-        // Check that arg_keys are unique
-        for (const auto &pair : argument_key_occurrences) {
-            const string &arg_key = pair.first;
-            int arg_key_occurrence = pair.second;
-            if (arg_key_occurrence > 1) {
+        // Check that parameters are unique
+        for (const auto &pair : parameter_occurrences) {
+            const string &parameter = pair.first;
+            int parameter_occurrence = pair.second;
+            if (parameter_occurrence > 1) {
                 errors.push_back(
-                    "The Argument '" + arg_key + "' in '" + feature_key + "' is defined " +
-                    to_string(arg_key_occurrence) + " times.");
+                        "The Parameter '" + parameter + "' in '" + feature_key + "' is defined " +
+                        to_string(parameter_occurrence) + " times.");
             }
         }
     }

--- a/src/search/plugins/raw_registry.cc
+++ b/src/search/plugins/raw_registry.cc
@@ -171,7 +171,6 @@ Features RawRegistry::collect_features(
                     + "' of feature '" + key + "'.");
             }
             ++occurrences[arg_info.key];
-
         }
         // Check that arg_keys are unique
         for (const auto &pair : occurrences) {
@@ -179,11 +178,10 @@ Features RawRegistry::collect_features(
             int occurrence = pair.second;
             if (occurrence > 1) {
                 errors.push_back(
-                        "The Argument '" + arg_key + "' in '" +  key + "' is defined " +
-                        to_string(occurrence) + " times.");
+                    "The Argument '" + arg_key + "' in '" + key + "' is defined " +
+                    to_string(occurrence) + " times.");
             }
         }
-
     }
 
     return features;

--- a/src/search/plugins/raw_registry.cc
+++ b/src/search/plugins/raw_registry.cc
@@ -118,28 +118,28 @@ SubcategoryPlugins RawRegistry::collect_subcategory_plugins(
 Features RawRegistry::collect_features(
     const SubcategoryPlugins &subcategory_plugins, vector<string> &errors) const {
     Features features;
-    unordered_map<string, int> key_occurrences;
+    unordered_map<string, int> feature_key_occurrences;
     for (const Plugin *plugin : plugins) {
         shared_ptr<Feature> feature = plugin->create_feature();
-        string key = feature->get_key();
-        key_occurrences[key]++;
-        features[key] = move(feature);
+        string feature_key = feature->get_key();
+        feature_key_occurrences[feature_key]++;
+        features[feature_key] = move(feature);
     }
 
-    // Check that keys are unique
-    for (const auto &pair : key_occurrences) {
-        const string &key = pair.first;
+    // Check that feature_keys are unique
+    for (const auto &pair : feature_key_occurrences) {
+        const string &feature_key = pair.first;
         int occurrences = pair.second;
         if (occurrences > 1) {
             errors.push_back(
                 to_string(occurrences) + " Features are defined for the key '" +
-                key + "'.");
+                feature_key + "'.");
         }
     }
 
     // Check that all subcategories used in features are defined
     for (const auto &item : features) {
-        const string &key = item.first;
+        const string &feature_key = item.first;
         const Feature &feature = *item.second;
         string subcategory = feature.get_subcategory();
 
@@ -147,39 +147,39 @@ Features RawRegistry::collect_features(
             const Type &type = feature.get_type();
             errors.push_back(
                 "Missing SubcategoryPlugin '" + subcategory + "' for Plugin '" +
-                key + "' of type " + type.name());
+                feature_key + "' of type " + type.name());
         }
     }
 
     // Check that all types used in features are defined
     unordered_set<type_index> missing_types;
     for (const auto &item : features) {
-        const string &key = item.first;
+        const string &feature_key = item.first;
         const Feature &feature = *item.second;
 
         const Type &type = feature.get_type();
         if (type == TypeRegistry::NO_TYPE) {
             errors.push_back(
-                "Missing Plugin for type of feature '" + key + "'.");
+                "Missing Plugin for type of feature '" + feature_key + "'.");
         }
 
-        unordered_map<string, int> occurrences;
+        unordered_map<string, int> argument_key_occurrences;
         for (const ArgumentInfo &arg_info : feature.get_arguments()) {
             if (arg_info.type == TypeRegistry::NO_TYPE) {
                 errors.push_back(
                     "Missing Plugin for type of argument '" + arg_info.key
-                    + "' of feature '" + key + "'.");
+                    + "' of feature '" + feature_key + "'.");
             }
-            ++occurrences[arg_info.key];
+            ++argument_key_occurrences[arg_info.key];
         }
         // Check that arg_keys are unique
-        for (const auto &pair : occurrences) {
+        for (const auto &pair : argument_key_occurrences) {
             const string &arg_key = pair.first;
-            int occurrence = pair.second;
-            if (occurrence > 1) {
+            int arg_key_occurrence = pair.second;
+            if (arg_key_occurrence > 1) {
                 errors.push_back(
-                    "The Argument '" + arg_key + "' in '" + key + "' is defined " +
-                    to_string(occurrence) + " times.");
+                    "The Argument '" + arg_key + "' in '" + feature_key + "' is defined " +
+                    to_string(arg_key_occurrence) + " times.");
             }
         }
     }

--- a/src/search/plugins/raw_registry.cc
+++ b/src/search/plugins/raw_registry.cc
@@ -178,8 +178,8 @@ Features RawRegistry::collect_features(
             int parameter_occurrence = pair.second;
             if (parameter_occurrence > 1) {
                 errors.push_back(
-                        "The Parameter '" + parameter + "' in '" + feature_key + "' is defined " +
-                        to_string(parameter_occurrence) + " times.");
+                    "The Parameter '" + parameter + "' in '" + feature_key + "' is defined " +
+                    to_string(parameter_occurrence) + " times.");
             }
         }
     }

--- a/src/search/plugins/raw_registry.cc
+++ b/src/search/plugins/raw_registry.cc
@@ -163,13 +163,27 @@ Features RawRegistry::collect_features(
                 "Missing Plugin for type of feature '" + key + "'.");
         }
 
+        unordered_map<string, int> occurrences;
         for (const ArgumentInfo &arg_info : feature.get_arguments()) {
             if (arg_info.type == TypeRegistry::NO_TYPE) {
                 errors.push_back(
                     "Missing Plugin for type of argument '" + arg_info.key
                     + "' of feature '" + key + "'.");
             }
+            ++occurrences[arg_info.key];
+
         }
+        // Check that arg_keys are unique
+        for (const auto &pair : occurrences) {
+            const string &arg_key = pair.first;
+            int occurrence = pair.second;
+            if (occurrence > 1) {
+                errors.push_back(
+                        "The Argument '" + arg_key + "' in '" +  key + "' is defined " +
+                        to_string(occurrence) + " times.");
+            }
+        }
+
     }
 
     return features;


### PR DESCRIPTION
[issue1113] add check for multiple parameter occurrences.
The RawRegistry detects if a feature uses two arguments with the same name and throws an error.
Additionally, we remove the duplicate use of the verbosity argument in the ipdb feature.