### PR TITLE
Add clang-tidy test that was erroneously commented out.

### DIFF
--- a/misc/style/run-clang-tidy.py
+++ b/misc/style/run-clang-tidy.py
@@ -62,7 +62,7 @@ def check_search_code_with_clang_tidy():
         # Enable with CheckTriviallyCopyableMove=0 when we require
         # clang-tidy >= 6.0 (see issue856).
         # "performance-move-const-arg",
-        #"performance-move-constructor-init",
+        "performance-move-constructor-init",
         "performance-no-automatic-move",
         # "performance-no-int-to-ptr",
         # "performance-noexcept-destructor",

--- a/src/search/potentials/potential_optimizer.cc
+++ b/src/search/potentials/potential_optimizer.cc
@@ -89,7 +89,7 @@ void PotentialOptimizer::optimize_for_samples(const vector<State> &samples) {
     solve_and_extract();
 }
 
-const shared_ptr<AbstractTask> PotentialOptimizer::get_task() const {
+shared_ptr<AbstractTask> PotentialOptimizer::get_task() const {
     return task;
 }
 

--- a/src/search/potentials/potential_optimizer.h
+++ b/src/search/potentials/potential_optimizer.h
@@ -60,7 +60,7 @@ public:
     explicit PotentialOptimizer(const plugins::Options &opts);
     ~PotentialOptimizer() = default;
 
-    const std::shared_ptr<AbstractTask> get_task() const;
+    std::shared_ptr<AbstractTask> get_task() const;
     bool potentials_are_bounded() const;
 
     void optimize_for_state(const State &state);


### PR DESCRIPTION
 And remove useless const.