### PR TITLE
add --approximate-negative-always option to translator

### DIFF
--- a/src/translate/axiom_rules.py
+++ b/src/translate/axiom_rules.py
@@ -62,6 +62,9 @@ def handle_axioms(operators, axioms, goals, layer_strategy):
     # the future. Similarly, it would be a good idea to remove the notion of
     # axiom layers and derived variable default values from the output.
     # (All derived variables should be binary and default to false.)
+# Malte Helmert suggested commenting out the following 2 lines
+# in conjunction with the blind heuristic this is sound
+# we instead introduce a commandline option changing compute_negative_axioms()
     with timers.timing("Computing negative axioms"):
         compute_negative_axioms(clusters)
 
@@ -270,7 +273,11 @@ def compute_negative_axioms(clusters):
                     cluster.axioms[variable].append(negated_axiom)
             else:
                 variable = next(iter(cluster.variables))
-                negated_axioms = negate(cluster.axioms[variable])
+                if options.approximate_negative_always:
+                    name = cluster.axioms[variable][0].name
+                    negated_axioms = [pddl.PropositionalAxiom(name, [], variable.negate())]
+                else:
+                    negated_axioms = negate(cluster.axioms[variable])
                 cluster.axioms[variable] += negated_axioms
 
 

--- a/src/translate/options.py
+++ b/src/translate/options.py
@@ -57,6 +57,10 @@ def parse_args():
         help="How to assign layers to derived variables. 'min' attempts to put as "
         "many variables into the same layer as possible, while 'max' puts each variable "
         "into its own layer unless it is part of a cycle.")
+
+    argparser.add_argument(
+        "--approximate-negative-always", dest="approximate_negative_always", action="store_true",
+        help="Always use approximate negative axioms.")
     return argparser.parse_args()
 
 


### PR DESCRIPTION
This option is intended for situations where computation of negative axioms causes timeouts before search even begins. This implements a suggestion of Salomé Eriksson in response to a Discord question by Joan Espasa on 18 March 2024, and wraps it in a new commandline option for the translator. Malte Helmert has suggested a similar approach in the past, commenting out the computation of negative axioms, but it is not clear to us precisely when that is sound so this implements the approximation approach instead.

We use FD with this option for our models of gravity-based tile matching puzzles to avoid unnecessary timeouts. Stock FD seldom gets past the negative axiom generation phase within the timeout, even for small instances. In contrast, with this option FD with a blind heuristic and a fine-grained PDDL model is often our best solver, usually beating human experts: see our [ModRef 2023 paper](https://modref.github.io/papers/ModRef2023_TowardsAModelOfPuzznic.pdf).