### PR TITLE
Update axiom documentation

### DIFF
--- a/src/search/heuristics/additive_heuristic.cc
+++ b/src/search/heuristics/additive_heuristic.cc
@@ -159,15 +159,11 @@ public:
 
         document_language_support("action costs", "supported");
         document_language_support("conditional effects", "supported");
-        document_language_support(
-            "axioms",
-            "supported (in the sense that the planner won't complain -- "
-            "handling of axioms might be very stupid "
-            "and even render the heuristic unsafe)");
+        document_language_support("axioms", "supported");
 
         document_property("admissible", "no");
         document_property("consistent", "no");
-        document_property("safe", "yes for tasks without axioms");
+        document_property("safe", "yes");
         document_property("preferred operators", "yes");
     }
 

--- a/src/search/heuristics/cea_heuristic.cc
+++ b/src/search/heuristics/cea_heuristic.cc
@@ -458,11 +458,7 @@ public:
 
         document_language_support("action costs", "supported");
         document_language_support("conditional effects", "supported");
-        document_language_support(
-            "axioms",
-            "supported (in the sense that the planner won't complain -- "
-            "handling of axioms might be very stupid "
-            "and even render the heuristic unsafe)");
+        document_language_support("axioms", "supported");
 
         document_property("admissible", "no");
         document_property("consistent", "no");

--- a/src/search/heuristics/cg_heuristic.cc
+++ b/src/search/heuristics/cg_heuristic.cc
@@ -303,11 +303,7 @@ public:
 
         document_language_support("action costs", "supported");
         document_language_support("conditional effects", "supported");
-        document_language_support(
-            "axioms",
-            "supported (in the sense that the planner won't complain -- "
-            "handling of axioms might be very stupid "
-            "and even render the heuristic unsafe)");
+        document_language_support("axioms", "supported");
 
         document_property("admissible", "no");
         document_property("consistent", "no");

--- a/src/search/heuristics/ff_heuristic.cc
+++ b/src/search/heuristics/ff_heuristic.cc
@@ -84,15 +84,11 @@ public:
 
         document_language_support("action costs", "supported");
         document_language_support("conditional effects", "supported");
-        document_language_support(
-            "axioms",
-            "supported (in the sense that the planner won't complain -- "
-            "handling of axioms might be very stupid "
-            "and even render the heuristic unsafe)");
+        document_language_support("axioms", "supported");
 
         document_property("admissible", "no");
         document_property("consistent", "no");
-        document_property("safe", "yes for tasks without axioms");
+        document_property("safe", "yes");
         document_property("preferred operators", "yes");
     }
 

--- a/src/search/heuristics/max_heuristic.cc
+++ b/src/search/heuristics/max_heuristic.cc
@@ -113,15 +113,11 @@ public:
 
         document_language_support("action costs", "supported");
         document_language_support("conditional effects", "supported");
-        document_language_support(
-            "axioms",
-            "supported (in the sense that the planner won't complain -- "
-            "handling of axioms might be very stupid "
-            "and even render the heuristic unsafe)");
+        document_language_support("axioms", "supported");
 
         document_property("admissible", "yes for tasks without axioms");
         document_property("consistent", "yes for tasks without axioms");
-        document_property("safe", "yes for tasks without axioms");
+        document_property("safe", "yes");
         document_property("preferred operators", "no");
     }
 

--- a/src/search/landmarks/landmark_cost_partitioning_heuristic.cc
+++ b/src/search/landmarks/landmark_cost_partitioning_heuristic.cc
@@ -18,13 +18,12 @@ namespace landmarks {
 LandmarkCostPartitioningHeuristic::LandmarkCostPartitioningHeuristic(
     const shared_ptr<LandmarkFactory> &lm_factory, bool pref,
     bool prog_goal, bool prog_gn, bool prog_r,
-    tasks::AxiomHandlingType axioms,
     const shared_ptr<AbstractTask> &transform, bool cache_estimates,
     const string &description, utils::Verbosity verbosity,
     CostPartitioningMethod cost_partitioning, bool alm,
     lp::LPSolverType lpsolver)
     : LandmarkHeuristic(
-          axioms, pref, transform, cache_estimates, description, verbosity) {
+          pref, transform, cache_estimates, description, verbosity) {
     if (log.is_at_least_normal()) {
         log << "Initializing landmark cost partitioning heuristic..." << endl;
     }

--- a/src/search/landmarks/landmark_cost_partitioning_heuristic.h
+++ b/src/search/landmarks/landmark_cost_partitioning_heuristic.h
@@ -26,7 +26,6 @@ public:
     LandmarkCostPartitioningHeuristic(
         const std::shared_ptr<LandmarkFactory> &lm_factory, bool pref,
         bool prog_goal, bool prog_gn, bool prog_r,
-        tasks::AxiomHandlingType axioms,
         const std::shared_ptr<AbstractTask> &transform,
         bool cache_estimates, const std::string &description,
         utils::Verbosity verbosity,

--- a/src/search/landmarks/landmark_heuristic.cc
+++ b/src/search/landmarks/landmark_heuristic.cc
@@ -14,12 +14,10 @@ using namespace std;
 
 namespace landmarks {
 LandmarkHeuristic::LandmarkHeuristic(
-    tasks::AxiomHandlingType axioms, bool use_preferred_operators,
+    bool use_preferred_operators,
     const shared_ptr<AbstractTask> &transform, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(tasks::get_default_value_axioms_task_if_needed(
-                    transform, axioms),
-                cache_estimates, description, verbosity),
+    : Heuristic(transform, cache_estimates, description, verbosity),
       use_preferred_operators(use_preferred_operators),
       successor_generator(nullptr) {
 }
@@ -228,7 +226,6 @@ void add_landmark_heuristic_options_to_feature(
         "prog_gn", "Use greedy-necessary ordering progression.", "true");
     feature.add_option<bool>(
         "prog_r", "Use reasonable ordering progression.", "true");
-    tasks::add_axioms_option_to_feature(feature);
     add_heuristic_options_to_feature(feature, description);
 
     feature.document_property("preferred operators",
@@ -236,8 +233,7 @@ void add_landmark_heuristic_options_to_feature(
 }
 
 tuple<shared_ptr<LandmarkFactory>, bool, bool, bool, bool,
-      tasks::AxiomHandlingType, shared_ptr<AbstractTask>, bool, string,
-      utils::Verbosity>
+      shared_ptr<AbstractTask>, bool, string, utils::Verbosity>
 get_landmark_heuristic_arguments_from_options(
     const plugins::Options &opts) {
     return tuple_cat(
@@ -247,7 +243,6 @@ get_landmark_heuristic_arguments_from_options(
             opts.get<bool>("prog_goal"),
             opts.get<bool>("prog_gn"),
             opts.get<bool>("prog_r")),
-        tasks::get_axioms_arguments_from_options(opts),
         get_heuristic_arguments_from_options(opts));
 }
 }

--- a/src/search/landmarks/landmark_heuristic.h
+++ b/src/search/landmarks/landmark_heuristic.h
@@ -46,7 +46,6 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     LandmarkHeuristic(
-        tasks::AxiomHandlingType axioms,
         bool use_preferred_operators,
         const std::shared_ptr<AbstractTask> &transform,
         bool cache_estimates, const std::string &description,
@@ -66,8 +65,7 @@ public:
 extern void add_landmark_heuristic_options_to_feature(
     plugins::Feature &feature, const std::string &description);
 extern std::tuple<std::shared_ptr<LandmarkFactory>, bool, bool, bool,
-                  bool, tasks::AxiomHandlingType,
-                  std::shared_ptr<AbstractTask>, bool, std::string,
+                  bool, std::shared_ptr<AbstractTask>, bool, std::string,
                   utils::Verbosity>
 get_landmark_heuristic_arguments_from_options(
     const plugins::Options &opts);

--- a/src/search/landmarks/landmark_sum_heuristic.cc
+++ b/src/search/landmarks/landmark_sum_heuristic.cc
@@ -117,37 +117,37 @@ bool LandmarkSumHeuristic::dead_ends_are_reliable() const {
 
 
 void add_landmark_sum_heuristic_options_to_feature(
-        plugins::Feature &feature, const string &description) {
+    plugins::Feature &feature, const string &description) {
     feature.document_synopsis(
-            "Landmark progression is implemented according to the following paper:"
-            + utils::format_conference_reference(
-                    {"Clemens Büchner", "Thomas Keller", "Salomé Eriksson", "Malte Helmert"},
-                    "Landmarks Progression in Heuristic Search",
-                    "https://ai.dmi.unibas.ch/papers/buechner-et-al-icaps2023.pdf",
-                    "Proceedings of the Thirty-Third International Conference on "
-                    "Automated Planning and Scheduling (ICAPS 2023)",
-                    "70-79",
-                    "AAAI Press",
-                    "2023"));
+        "Landmark progression is implemented according to the following paper:"
+        + utils::format_conference_reference(
+            {"Clemens Büchner", "Thomas Keller", "Salomé Eriksson", "Malte Helmert"},
+            "Landmarks Progression in Heuristic Search",
+            "https://ai.dmi.unibas.ch/papers/buechner-et-al-icaps2023.pdf",
+            "Proceedings of the Thirty-Third International Conference on "
+            "Automated Planning and Scheduling (ICAPS 2023)",
+            "70-79",
+            "AAAI Press",
+            "2023"));
 
     feature.add_option<shared_ptr<LandmarkFactory>>(
-            "lm_factory",
-            "the set of landmarks to use for this heuristic. "
-            "The set of landmarks can be specified here, "
-            "or predefined (see LandmarkFactory).");
+        "lm_factory",
+        "the set of landmarks to use for this heuristic. "
+        "The set of landmarks can be specified here, "
+        "or predefined (see LandmarkFactory).");
     tasks::add_axioms_option_to_feature(feature);
     feature.add_option<bool>(
-            "pref",
-            "enable preferred operators (see note below)",
-            "false");
+        "pref",
+        "enable preferred operators (see note below)",
+        "false");
     /* TODO: Do we really want these options or should we just always progress
         everything we can? */
     feature.add_option<bool>(
-            "prog_goal", "Use goal progression.", "true");
+        "prog_goal", "Use goal progression.", "true");
     feature.add_option<bool>(
-            "prog_gn", "Use greedy-necessary ordering progression.", "true");
+        "prog_gn", "Use greedy-necessary ordering progression.", "true");
     feature.add_option<bool>(
-            "prog_r", "Use reasonable ordering progression.", "true");
+        "prog_r", "Use reasonable ordering progression.", "true");
     add_heuristic_options_to_feature(feature, description);
 
     feature.document_property("preferred operators",
@@ -155,19 +155,19 @@ void add_landmark_sum_heuristic_options_to_feature(
 }
 
 tuple<shared_ptr<LandmarkFactory>, tasks::AxiomHandlingType, bool, bool, bool,
-        bool, shared_ptr<AbstractTask>, bool, string, utils::Verbosity>
+      bool, shared_ptr<AbstractTask>, bool, string, utils::Verbosity>
 get_landmark_sum_heuristic_arguments_from_options(
-        const plugins::Options &opts) {
+    const plugins::Options &opts) {
     return tuple_cat(
-            make_tuple(
-                    opts.get<shared_ptr<LandmarkFactory>>("lm_factory")),
-            tasks::get_axioms_arguments_from_options(opts),
-            make_tuple(
-                    opts.get<bool>("pref"),
-                    opts.get<bool>("prog_goal"),
-                    opts.get<bool>("prog_gn"),
-                    opts.get<bool>("prog_r")),
-            get_heuristic_arguments_from_options(opts));
+        make_tuple(
+            opts.get<shared_ptr<LandmarkFactory>>("lm_factory")),
+        tasks::get_axioms_arguments_from_options(opts),
+        make_tuple(
+            opts.get<bool>("pref"),
+            opts.get<bool>("prog_goal"),
+            opts.get<bool>("prog_gn"),
+            opts.get<bool>("prog_r")),
+        get_heuristic_arguments_from_options(opts));
 }
 
 class LandmarkSumHeuristicFeature

--- a/src/search/landmarks/landmark_sum_heuristic.cc
+++ b/src/search/landmarks/landmark_sum_heuristic.cc
@@ -31,14 +31,15 @@ static bool are_dead_ends_reliable(
 }
 
 LandmarkSumHeuristic::LandmarkSumHeuristic(
+    tasks::AxiomHandlingType axioms,
     const shared_ptr<LandmarkFactory> &lm_factory, bool pref,
     bool prog_goal, bool prog_gn, bool prog_r,
-    tasks::AxiomHandlingType axioms,
     const shared_ptr<AbstractTask> &transform, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
     : LandmarkHeuristic(
-          axioms, pref, transform, cache_estimates,
-          description, verbosity),
+          pref,
+          tasks::get_default_value_axioms_task_if_needed(transform, axioms),
+          cache_estimates, description, verbosity),
       dead_ends_reliable(
           are_dead_ends_reliable(lm_factory, task_proxy)) {
     if (log.is_at_least_normal()) {
@@ -142,6 +143,7 @@ public:
                 "127-177",
                 "2010"));
 
+        tasks::add_axioms_option_to_feature(*this);
         add_landmark_heuristic_options_to_feature(
             *this, "landmark_sum_heuristic");
 
@@ -199,6 +201,7 @@ public:
         const plugins::Options &opts,
         const utils::Context &) const override {
         return plugins::make_shared_from_arg_tuples<LandmarkSumHeuristic>(
+            tasks::get_axioms_arguments_from_options(opts),
             get_landmark_heuristic_arguments_from_options(opts));
     }
 };

--- a/src/search/landmarks/landmark_sum_heuristic.cc
+++ b/src/search/landmarks/landmark_sum_heuristic.cc
@@ -185,15 +185,14 @@ public:
             "conditional_effects",
             "supported if the LandmarkFactory supports them; otherwise "
             "ignored");
-        document_language_support("axioms", "ignored");
+        document_language_support("axioms", "supported");
 
         document_property("admissible", "no");
         document_property("consistent", "no");
         document_property(
             "safe",
-            "yes except on tasks with axioms or on tasks with "
-            "conditional effects when using a LandmarkFactory "
-            "not supporting them");
+            "yes except on tasks with conditional effects when "
+            "using a LandmarkFactory not supporting them");
     }
 
     virtual shared_ptr<LandmarkSumHeuristic> create_component(

--- a/src/search/landmarks/landmark_sum_heuristic.cc
+++ b/src/search/landmarks/landmark_sum_heuristic.cc
@@ -31,8 +31,8 @@ static bool are_dead_ends_reliable(
 }
 
 LandmarkSumHeuristic::LandmarkSumHeuristic(
-    tasks::AxiomHandlingType axioms,
-    const shared_ptr<LandmarkFactory> &lm_factory, bool pref,
+    const shared_ptr<LandmarkFactory> &lm_factory,
+    tasks::AxiomHandlingType axioms, bool pref,
     bool prog_goal, bool prog_gn, bool prog_r,
     const shared_ptr<AbstractTask> &transform, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
@@ -115,6 +115,61 @@ bool LandmarkSumHeuristic::dead_ends_are_reliable() const {
     return dead_ends_reliable;
 }
 
+
+void add_landmark_sum_heuristic_options_to_feature(
+        plugins::Feature &feature, const string &description) {
+    feature.document_synopsis(
+            "Landmark progression is implemented according to the following paper:"
+            + utils::format_conference_reference(
+                    {"Clemens Büchner", "Thomas Keller", "Salomé Eriksson", "Malte Helmert"},
+                    "Landmarks Progression in Heuristic Search",
+                    "https://ai.dmi.unibas.ch/papers/buechner-et-al-icaps2023.pdf",
+                    "Proceedings of the Thirty-Third International Conference on "
+                    "Automated Planning and Scheduling (ICAPS 2023)",
+                    "70-79",
+                    "AAAI Press",
+                    "2023"));
+
+    feature.add_option<shared_ptr<LandmarkFactory>>(
+            "lm_factory",
+            "the set of landmarks to use for this heuristic. "
+            "The set of landmarks can be specified here, "
+            "or predefined (see LandmarkFactory).");
+    tasks::add_axioms_option_to_feature(feature);
+    feature.add_option<bool>(
+            "pref",
+            "enable preferred operators (see note below)",
+            "false");
+    /* TODO: Do we really want these options or should we just always progress
+        everything we can? */
+    feature.add_option<bool>(
+            "prog_goal", "Use goal progression.", "true");
+    feature.add_option<bool>(
+            "prog_gn", "Use greedy-necessary ordering progression.", "true");
+    feature.add_option<bool>(
+            "prog_r", "Use reasonable ordering progression.", "true");
+    add_heuristic_options_to_feature(feature, description);
+
+    feature.document_property("preferred operators",
+                              "yes (if enabled; see ``pref`` option)");
+}
+
+tuple<shared_ptr<LandmarkFactory>, tasks::AxiomHandlingType, bool, bool, bool,
+        bool, shared_ptr<AbstractTask>, bool, string, utils::Verbosity>
+get_landmark_sum_heuristic_arguments_from_options(
+        const plugins::Options &opts) {
+    return tuple_cat(
+            make_tuple(
+                    opts.get<shared_ptr<LandmarkFactory>>("lm_factory")),
+            tasks::get_axioms_arguments_from_options(opts),
+            make_tuple(
+                    opts.get<bool>("pref"),
+                    opts.get<bool>("prog_goal"),
+                    opts.get<bool>("prog_gn"),
+                    opts.get<bool>("prog_r")),
+            get_heuristic_arguments_from_options(opts));
+}
+
 class LandmarkSumHeuristicFeature
     : public plugins::TypedFeature<Evaluator, LandmarkSumHeuristic> {
 public:
@@ -143,8 +198,7 @@ public:
                 "127-177",
                 "2010"));
 
-        tasks::add_axioms_option_to_feature(*this);
-        add_landmark_heuristic_options_to_feature(
+        add_landmark_sum_heuristic_options_to_feature(
             *this, "landmark_sum_heuristic");
 
         document_note(
@@ -201,8 +255,7 @@ public:
         const plugins::Options &opts,
         const utils::Context &) const override {
         return plugins::make_shared_from_arg_tuples<LandmarkSumHeuristic>(
-            tasks::get_axioms_arguments_from_options(opts),
-            get_landmark_heuristic_arguments_from_options(opts));
+            get_landmark_sum_heuristic_arguments_from_options(opts));
     }
 };
 

--- a/src/search/landmarks/landmark_sum_heuristic.h
+++ b/src/search/landmarks/landmark_sum_heuristic.h
@@ -17,23 +17,14 @@ class LandmarkSumHeuristic : public LandmarkHeuristic {
     int get_heuristic_value(const State &ancestor_state) override;
 public:
     LandmarkSumHeuristic(
-        const std::shared_ptr<LandmarkFactory> &lm_factory,
-        tasks::AxiomHandlingType axioms, bool pref,
+        const std::shared_ptr<LandmarkFactory> &lm_factory, bool pref,
         bool prog_goal, bool prog_gn, bool prog_r,
         const std::shared_ptr<AbstractTask> &transform,
         bool cache_estimates, const std::string &description,
-        utils::Verbosity verbosity);
+        utils::Verbosity verbosity, tasks::AxiomHandlingType axioms);
 
     virtual bool dead_ends_are_reliable() const override;
 };
-
-extern void add_landmark_sum_heuristic_options_to_feature(
-    plugins::Feature &feature, const std::string &description);
-extern std::tuple<std::shared_ptr<LandmarkFactory>, tasks::AxiomHandlingType,
-                  bool, bool, bool, bool, std::shared_ptr<AbstractTask>, bool,
-                  std::string, utils::Verbosity>
-get_landmark_sum_heuristic_arguments_from_options(
-    const plugins::Options &opts);
 }
 
 #endif

--- a/src/search/landmarks/landmark_sum_heuristic.h
+++ b/src/search/landmarks/landmark_sum_heuristic.h
@@ -17,8 +17,8 @@ class LandmarkSumHeuristic : public LandmarkHeuristic {
     int get_heuristic_value(const State &ancestor_state) override;
 public:
     LandmarkSumHeuristic(
-        tasks::AxiomHandlingType axioms,
-        const std::shared_ptr<LandmarkFactory> &lm_factory, bool pref,
+        const std::shared_ptr<LandmarkFactory> &lm_factory,
+        tasks::AxiomHandlingType axioms, bool pref,
         bool prog_goal, bool prog_gn, bool prog_r,
         const std::shared_ptr<AbstractTask> &transform,
         bool cache_estimates, const std::string &description,
@@ -26,6 +26,14 @@ public:
 
     virtual bool dead_ends_are_reliable() const override;
 };
+
+extern void add_landmark_sum_heuristic_options_to_feature(
+    plugins::Feature &feature, const std::string &description);
+extern std::tuple<std::shared_ptr<LandmarkFactory>, tasks::AxiomHandlingType,
+                  bool, bool, bool, bool, std::shared_ptr<AbstractTask>, bool,
+                  std::string, utils::Verbosity>
+get_landmark_sum_heuristic_arguments_from_options(
+    const plugins::Options &opts);
 }
 
 #endif

--- a/src/search/landmarks/landmark_sum_heuristic.h
+++ b/src/search/landmarks/landmark_sum_heuristic.h
@@ -17,9 +17,9 @@ class LandmarkSumHeuristic : public LandmarkHeuristic {
     int get_heuristic_value(const State &ancestor_state) override;
 public:
     LandmarkSumHeuristic(
+        tasks::AxiomHandlingType axioms,
         const std::shared_ptr<LandmarkFactory> &lm_factory, bool pref,
         bool prog_goal, bool prog_gn, bool prog_r,
-        tasks::AxiomHandlingType axioms,
         const std::shared_ptr<AbstractTask> &transform,
         bool cache_estimates, const std::string &description,
         utils::Verbosity verbosity);

--- a/src/search/tasks/default_value_axioms_task.cc
+++ b/src/search/tasks/default_value_axioms_task.cc
@@ -421,9 +421,9 @@ static plugins::TypedEnumPlugin<AxiomHandlingType> _enum_plugin({
         {"approximate_negative_cycles",
          "Overapproximate negated axioms for all derived variables which "
          "have cyclic dependencies by setting an empty condition, "
-         "indicating the default value can always be achieved for free."
+         "indicating the default value can always be achieved for free. "
          "For all other derived variables, the negated axioms are computed"
          "exactly. Note that this can potentially lead to a combinatorial "
-         "explosion"}
+         "explosion."}
     });
 }


### PR DESCRIPTION
Update documentation for axiom support and safety properties for heuristics that have the new axioms option.
Furthermore, removed the axioms option from landmark_cost_partitioning_heuristic since it does not support axioms.