### PR TITLE
Fix if/else logic for computing cache_misses in cg heuristic

### DIFF
--- a/src/search/heuristics/cg_heuristic.cc
+++ b/src/search/heuristics/cg_heuristic.cc
@@ -98,9 +98,9 @@ int CGHeuristic::get_transition_cost(const State &state,
         if (cached_val != CGCache::NOT_COMPUTED) {
             ++cache_hits;
             return cached_val;
+        } else {
+            ++cache_misses;
         }
-    } else {
-        ++cache_misses;
     }
 
     ValueNode *start = &dtg->nodes[start_val];


### PR DESCRIPTION
There seems to be a bug in the computation of `cache_misses` in the cg heuristic. It looks like it should only be increased if `use_the_cache` is true and `cached_val != CGCache::NOT_COMPUTED`. 