### PR TITLE
[issue1183] Improve how RHW determines landmark preconditions.

### DIFF
--- a/src/search/landmarks/landmark_factory_rpg_sasp.cc
+++ b/src/search/landmarks/landmark_factory_rpg_sasp.cc
@@ -131,12 +131,12 @@ void LandmarkFactoryRpgSasp::get_greedy_preconditions_for_lm(
                         current_cond.emplace(effect_condition.get_variable().get_id(),
                                              effect_condition.get_value());
                 }
+                if (init) {
+                    init = false;
+                    intersection = current_cond;
+                } else
+                    intersection = _intersect(intersection, current_cond);
             }
-            if (init) {
-                init = false;
-                intersection = current_cond;
-            } else
-                intersection = _intersect(intersection, current_cond);
         }
     }
     result.insert(intersection.begin(), intersection.end());


### PR DESCRIPTION
The approximation of landmark preconditions may now yield larger, more accurate
sets in the presence of conditional effects. This potentially leads to more
landmarks found in the RHW backchaining landmark generation. The change has no
effect in the optimal benchmark suite and only affects four domains in the
satisficing benchmark suite: flashfill (~69% more landmarks), miconic-fulladl
(~126% more landmarks), miconic-simpleadl (~88% more landmarks), and settlers
(~88% more landmarks). This increase has no significant impact on the search
behavior of LAMA and LAMA-first.