### PR TITLE
remove timer.h in logging.h: logging.h does not depend on it

### DIFF
--- a/src/search/landmarks/landmark_heuristic.cc
+++ b/src/search/landmarks/landmark_heuristic.cc
@@ -9,6 +9,7 @@
 #include "../tasks/cost_adapted_task.h"
 #include "../tasks/root_task.h"
 #include "../utils/markup.h"
+#include "../utils/timer.h"
 
 using namespace std;
 

--- a/src/search/utils/logging.cc
+++ b/src/search/utils/logging.cc
@@ -1,7 +1,7 @@
 #include "logging.h"
 
 #include "system.h"
-#include "timer.h" 		// for g_timer
+#include "timer.h"
 
 #include "../plugins/plugin.h"
 

--- a/src/search/utils/logging.cc
+++ b/src/search/utils/logging.cc
@@ -1,7 +1,7 @@
 #include "logging.h"
 
 #include "system.h"
-#include "timer.h"
+#include "timer.h" 		// for g_timer
 
 #include "../plugins/plugin.h"
 

--- a/src/search/utils/logging.h
+++ b/src/search/utils/logging.h
@@ -3,7 +3,6 @@
 
 #include "exceptions.h"
 #include "system.h"
-#include "timer.h"
 
 #include <memory>
 #include <ostream>


### PR DESCRIPTION
This is a minor contribution.

The include statement for timer.h in logging.h is unnecessary; While logging.cc uses `g_timer`, logging.h does not use Duration, Timer or their instances.

landmark_heuristic.cc depended on this implicit inclusion, therefore in the commit it has a new include statement.
This style is consistent with the rest of the code base which includes timer.h only when it is necessary.
