### PR TITLE
[issue1214] prevent synopsis overwriting.

### DIFF
--- a/src/search/landmarks/landmark_cost_partitioning_heuristic.cc
+++ b/src/search/landmarks/landmark_cost_partitioning_heuristic.cc
@@ -89,25 +89,6 @@ public:
     LandmarkCostPartitioningHeuristicFeature()
         : TypedFeature("landmark_cost_partitioning") {
         document_title("Landmark cost partitioning heuristic");
-        document_synopsis(
-            "Formerly known as the admissible landmark heuristic.\n"
-            "See the papers" +
-            utils::format_conference_reference(
-                {"Erez Karpas", "Carmel Domshlak"},
-                "Cost-Optimal Planning with Landmarks",
-                "https://www.ijcai.org/Proceedings/09/Papers/288.pdf",
-                "Proceedings of the 21st International Joint Conference on "
-                "Artificial Intelligence (IJCAI 2009)",
-                "1728-1733", "AAAI Press", "2009") +
-            "and" +
-            utils::format_conference_reference(
-                {"Emil Keyder and Silvia Richter and Malte Helmert"},
-                "Sound and Complete Landmarks for And/Or Graphs",
-                "https://ai.dmi.unibas.ch/papers/keyder-et-al-ecai2010.pdf",
-                "Proceedings of the 19th European Conference on Artificial "
-                "Intelligence (ECAI 2010)",
-                "335-340", "IOS Press", "2010"));
-
         /*
           We usually have the options of base classes behind the options
           of specific implementations. In the case of landmark
@@ -125,6 +106,25 @@ public:
         add_option<bool>("alm", "use action landmarks", "true");
         lp::add_lp_solver_option_to_feature(*this);
 
+        document_note(
+            "History Note",
+            "Formerly known as the admissible landmark heuristic.\n"
+            "See the papers" +
+            utils::format_conference_reference(
+                {"Erez Karpas", "Carmel Domshlak"},
+                "Cost-Optimal Planning with Landmarks",
+                "https://www.ijcai.org/Proceedings/09/Papers/288.pdf",
+                "Proceedings of the 21st International Joint Conference on "
+                "Artificial Intelligence (IJCAI 2009)",
+                "1728-1733", "AAAI Press", "2009") +
+            "and" +
+            utils::format_conference_reference(
+                {"Emil Keyder and Silvia Richter and Malte Helmert"},
+                "Sound and Complete Landmarks for And/Or Graphs",
+                "https://ai.dmi.unibas.ch/papers/keyder-et-al-ecai2010.pdf",
+                "Proceedings of the 19th European Conference on Artificial "
+                "Intelligence (ECAI 2010)",
+                "335-340", "IOS Press", "2010"));
         document_note(
             "Usage with A*",
             "We recommend to add this heuristic as lazy_evaluator when using "

--- a/src/search/landmarks/landmark_cost_partitioning_heuristic.cc
+++ b/src/search/landmarks/landmark_cost_partitioning_heuristic.cc
@@ -110,21 +110,21 @@ public:
             "History Note",
             "Formerly known as the admissible landmark heuristic.\n"
             "See the papers" +
-            utils::format_conference_reference(
-                {"Erez Karpas", "Carmel Domshlak"},
-                "Cost-Optimal Planning with Landmarks",
-                "https://www.ijcai.org/Proceedings/09/Papers/288.pdf",
-                "Proceedings of the 21st International Joint Conference on "
-                "Artificial Intelligence (IJCAI 2009)",
-                "1728-1733", "AAAI Press", "2009") +
-            "and" +
-            utils::format_conference_reference(
-                {"Emil Keyder and Silvia Richter and Malte Helmert"},
-                "Sound and Complete Landmarks for And/Or Graphs",
-                "https://ai.dmi.unibas.ch/papers/keyder-et-al-ecai2010.pdf",
-                "Proceedings of the 19th European Conference on Artificial "
-                "Intelligence (ECAI 2010)",
-                "335-340", "IOS Press", "2010"));
+                utils::format_conference_reference(
+                    {"Erez Karpas", "Carmel Domshlak"},
+                    "Cost-Optimal Planning with Landmarks",
+                    "https://www.ijcai.org/Proceedings/09/Papers/288.pdf",
+                    "Proceedings of the 21st International Joint Conference on "
+                    "Artificial Intelligence (IJCAI 2009)",
+                    "1728-1733", "AAAI Press", "2009") +
+                "and" +
+                utils::format_conference_reference(
+                    {"Emil Keyder and Silvia Richter and Malte Helmert"},
+                    "Sound and Complete Landmarks for And/Or Graphs",
+                    "https://ai.dmi.unibas.ch/papers/keyder-et-al-ecai2010.pdf",
+                    "Proceedings of the 19th European Conference on Artificial "
+                    "Intelligence (ECAI 2010)",
+                    "335-340", "IOS Press", "2010"));
         document_note(
             "Usage with A*",
             "We recommend to add this heuristic as lazy_evaluator when using "

--- a/src/search/landmarks/landmark_sum_heuristic.cc
+++ b/src/search/landmarks/landmark_sum_heuristic.cc
@@ -112,7 +112,20 @@ class LandmarkSumHeuristicFeature
 public:
     LandmarkSumHeuristicFeature() : TypedFeature("landmark_sum") {
         document_title("Landmark sum heuristic");
-        document_synopsis(
+        /*
+          We usually have the options of base classes behind the options
+          of specific implementations. In the case of landmark
+          heuristics, we decided to have the common options at the front
+          because it feels more natural to specify the landmark factory
+          before the more specific arguments like the used LP solver in
+          the case of an optimal cost partitioning heuristic.
+        */
+        add_landmark_heuristic_options_to_feature(
+            *this, "landmark_sum_heuristic");
+        tasks::add_axioms_option_to_feature(*this);
+
+        document_note(
+            "History Note",
             "Formerly known as the landmark heuristic or landmark count "
             "heuristic.\n"
             "See the papers" +
@@ -130,18 +143,6 @@ public:
                 "http://www.aaai.org/Papers/JAIR/Vol39/JAIR-3903.pdf",
                 "Journal of Artificial Intelligence Research", "39", "127-177",
                 "2010"));
-        /*
-          We usually have the options of base classes behind the options
-          of specific implementations. In the case of landmark
-          heuristics, we decided to have the common options at the front
-          because it feels more natural to specify the landmark factory
-          before the more specific arguments like the used LP solver in
-          the case of an optimal cost partitioning heuristic.
-        */
-        add_landmark_heuristic_options_to_feature(
-            *this, "landmark_sum_heuristic");
-        tasks::add_axioms_option_to_feature(*this);
-
         document_note(
             "Note on performance for satisficing planning",
             "The cost of a landmark is based on the cost of the operators that "

--- a/src/search/landmarks/landmark_sum_heuristic.cc
+++ b/src/search/landmarks/landmark_sum_heuristic.cc
@@ -129,20 +129,20 @@ public:
             "Formerly known as the landmark heuristic or landmark count "
             "heuristic.\n"
             "See the papers" +
-            utils::format_conference_reference(
-                {"Silvia Richter", "Malte Helmert", "Matthias Westphal"},
-                "Landmarks Revisited",
-                "https://ai.dmi.unibas.ch/papers/richter-et-al-aaai2008.pdf",
-                "Proceedings of the 23rd AAAI Conference on Artificial "
-                "Intelligence (AAAI 2008)",
-                "975-982", "AAAI Press", "2008") +
-            "and" +
-            utils::format_journal_reference(
-                {"Silvia Richter", "Matthias Westphal"},
-                "The LAMA Planner: Guiding Cost-Based Anytime Planning with Landmarks",
-                "http://www.aaai.org/Papers/JAIR/Vol39/JAIR-3903.pdf",
-                "Journal of Artificial Intelligence Research", "39", "127-177",
-                "2010"));
+                utils::format_conference_reference(
+                    {"Silvia Richter", "Malte Helmert", "Matthias Westphal"},
+                    "Landmarks Revisited",
+                    "https://ai.dmi.unibas.ch/papers/richter-et-al-aaai2008.pdf",
+                    "Proceedings of the 23rd AAAI Conference on Artificial "
+                    "Intelligence (AAAI 2008)",
+                    "975-982", "AAAI Press", "2008") +
+                "and" +
+                utils::format_journal_reference(
+                    {"Silvia Richter", "Matthias Westphal"},
+                    "The LAMA Planner: Guiding Cost-Based Anytime Planning with Landmarks",
+                    "http://www.aaai.org/Papers/JAIR/Vol39/JAIR-3903.pdf",
+                    "Journal of Artificial Intelligence Research", "39",
+                    "127-177", "2010"));
         document_note(
             "Note on performance for satisficing planning",
             "The cost of a landmark is based on the cost of the operators that "

--- a/src/search/plugins/plugin.cc
+++ b/src/search/plugins/plugin.cc
@@ -10,14 +10,17 @@ Feature::Feature(const Type &type, const string &key)
 }
 
 void Feature::document_subcategory(const string &subcategory) {
+    assert(this->subcategory.empty());
     this->subcategory = subcategory;
 }
 
 void Feature::document_title(const string &title) {
+    assert(this->title.empty());
     this->title = title;
 }
 
 void Feature::document_synopsis(const string &note) {
+    assert(this->synopsis.empty());
     synopsis = note;
 }
 
@@ -106,6 +109,7 @@ bool CategoryPlugin::supports_variable_binding() const {
 }
 
 void CategoryPlugin::document_synopsis(const string &synopsis) {
+    assert(this->synopsis.empty());
     this->synopsis = synopsis;
 }
 
@@ -119,10 +123,12 @@ SubcategoryPlugin::SubcategoryPlugin(const string &subcategory)
 }
 
 void SubcategoryPlugin::document_title(const string &title) {
+    assert(this->title.empty());
     this->title = title;
 }
 
 void SubcategoryPlugin::document_synopsis(const string &synopsis) {
+    assert(this->synopsis.empty());
     this->synopsis = synopsis;
 }
 


### PR DESCRIPTION
Move part that would cause the overwriting of the synopsis to a note.

Add assertions to prevent overwriting in the future.