### PR TITLE
Issue1220: "external" construction of translator distribution.

### DIFF
--- a/misc/releases/prepare-translator-package.sh
+++ b/misc/releases/prepare-translator-package.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: ./prepare-translator-package.sh 19.06"
+    exit 1
+fi
+MAJOR=$1
+
+if [[ ! "$MAJOR" =~ ^[1-9][0-9]\.[0-9][0-9]$ ]]; then
+    echo "Unrecognized version number '$MAJOR'. Expected the format YY.MM (e.g. 19.06)."
+    exit 1
+fi
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+PACKAGEDIR=$SCRIPTDIR/translator-$MAJOR
+mkdir $PACKAGEDIR 
+cp -r $SCRIPTDIR/translator/* $PACKAGEDIR/
+mkdir $PACKAGEDIR/src
+mkdir $PACKAGEDIR/src/downward/
+cp -r $SCRIPTDIR/../../src/translate $PACKAGEDIR/src/downward/
+cp -r $SCRIPTDIR/../../LICENSE.md $PACKAGEDIR/
+TRANSLATEDIR=$PACKAGEDIR/src/downward/translate
+sed -i "s/from translate/from downward.translate/g" $TRANSLATEDIR/*.py
+sed -i "s/from translate/from downward.translate/g" $TRANSLATEDIR/*/*.py
+echo $MAJOR > $PACKAGEDIR/VERSION
+
+ENVDIR=env-translate-$MAJOR
+python3 -m venv $ENVDIR
+source $ENVDIR/bin/activate
+python3 -m pip install --upgrade build
+cd $PACKAGEDIR
+python3 -m build

--- a/misc/releases/translator/README.md
+++ b/misc/releases/translator/README.md
@@ -1,0 +1,11 @@
+# Fast Downward translator
+
+This package contains the translator of the [Fast Downward planning
+system](https://www.fast-downward.org). It parses planning tasks specified in
+the Planning Domain Definition Language PDDL, performs several transformations
+and generates the
+[`output.sas` format](https://www.fast-downward.org/latest/documentation/translator-output-format/)
+that serves as the input for the search component of the planning system.
+
+At the moment, you can call it with `python3 -m downward.translate`.
+

--- a/misc/releases/translator/pyproject.toml
+++ b/misc/releases/translator/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "downward_translate"
+dynamic = ["version"]
+description = "Translator of the Fast Downward planning system"
+authors = [
+    {name = "UNIBAS Team"},
+]
+maintainers = [
+    {name = "Gabriele Röger", email = "gabriele.roeger@unibas.ch"},
+]
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+license = "GPL-3.0-only"
+
+[project.urls]
+Homepage = "https://www.fast-downward.org"
+Issues = "https://issues.fast-downward.org"
+
+[tool.setuptools.dynamic]
+version = {file = "VERSION"}
+
+[build-system]
+requires = ["setuptools >= 77.0.3"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This is the variant of making a distribution of the Fast Downward translator **without interfering with the existing code base**.

The large **disadvantage** is that the distributed translator would be used as downward.translate while the internal package is only translate. This difference affects both, the external usage as well as the code of the translator.

(The details of the toml file are no proposal for the actual entries.)