### PR TITLE
Add translator documentation to website

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -39,6 +39,7 @@ jobs:
           cd misc/autodoc
           python3 -m pip install -r requirements.txt
           python3 generate-docs.py
+          python3 generate-translate-docs.py
           cd ../../..
 
       - name: Move website material to website repo

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,6 +2,7 @@ This file controls the navigation below "documentation" on the website.
 
   -  [](README.md)
   -  [Planner usage](planner-usage.md)
+  -  [Translator usage](translator-usage.md)
   -  [Search plugins](search/)
   -  [Syntax for search plugins](search-plugin-syntax.md)
   -  [Exit codes](exit-codes.md)

--- a/docs/planner-usage.md
+++ b/docs/planner-usage.md
@@ -1,4 +1,4 @@
-# Usage
+# Planner Usage
 
 Fast Downward is a domain-independent classical planning system that consists of two main components:
 
@@ -26,7 +26,7 @@ Note:
 
 -   Giving the domain file as input is optional. 
     In case no domain file is specified, the component will search for a file called `domain.pddl` located in the same directory as the task file. 
--   Translator component options can be specified after the input files following the `--translator-options` flag.
+-   Translator component options can be specified after the input files following the `--translator-options` flag. See [translator usage](translator-usage.md) for details.
 
 ## Search component
 To run a search on a PDDL input task run the following:

--- a/misc/autodoc/generate-translate-docs.py
+++ b/misc/autodoc/generate-translate-docs.py
@@ -57,8 +57,8 @@ def action_to_markdown(parser: argparse.ArgumentParser, action: argparse.Action)
         name = ", ".join(names)
     else:
         name = f"`{action.dest}`"
-        # Expand %(default)s, %(choices)s, etc.
 
+    # Expand %(default)s, %(choices)s, etc.
     help_text = action.help or ""
     if help_text is not argparse.SUPPRESS:
         params = {

--- a/misc/autodoc/generate-translate-docs.py
+++ b/misc/autodoc/generate-translate-docs.py
@@ -20,6 +20,8 @@ Fast Downward's PDDL to SAS^+ translator can be called through Fast Downward's d
 ./fast-downward.py --translate [domain] problem [--translate-options OPTIONS]
 ```
 
+## Options
+
 """
 
 def parse_args():
@@ -38,19 +40,47 @@ def import_argparser_from_translator():
     return options.get_arg_parser()
 
 
+def action_to_markdown(parser: argparse.ArgumentParser, action: argparse.Action):
+    if action.option_strings:
+        names = []
+        for opt in action.option_strings:
+            if action.choices is not None:
+                choice_str = ",".join(map(str, action.choices))
+                names.append(f"`{opt} {{{choice_str}}}`")
+            elif action.metavar is not None:
+                names.append(f"`{opt} {action.metavar}`")
+            elif action.nargs != 0:
+                metavar = action.dest.upper()
+                names.append(f"`{opt} {metavar}`")
+            else:
+                names.append(f"`{opt}`")
+        name = ", ".join(names)
+    else:
+        name = f"`{action.dest}`"
+        # Expand %(default)s, %(choices)s, etc.
+
+    help_text = action.help or ""
+    if help_text is not argparse.SUPPRESS:
+        params = {
+            "default": action.default,
+            "prog": parser.prog,
+            "type": action.type,
+            "choices": action.choices,
+            "metavar": action.metavar,
+            "dest": action.dest,
+        }
+        try:
+            help_text = help_text % params
+        except Exception:
+            pass
+
+    return f"### {name}\n{help_text}\n"
+
+
 def parser_to_markdown(parser: argparse.ArgumentParser):
     lines = [INTRO_TEXT]
-    lines.append("## Options")
-    lines.append("")
-
     for action in parser._actions:
-        if action.option_strings:
-            name = ", ".join(f"`{s}`" for s in action.option_strings)
-        else:
-            name = f"`{action.dest}`"
-        lines.append(f"### {name}")
-        lines.append(action.help)
-        lines.append("")
+        lines.append(action_to_markdown(parser, action))
     return "\n".join(lines)
 
 

--- a/misc/autodoc/generate-translate-docs.py
+++ b/misc/autodoc/generate-translate-docs.py
@@ -1,0 +1,72 @@
+#! /usr/bin/env python3
+
+import argparse
+import logging
+from pathlib import Path
+import subprocess
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT_DIR = SCRIPT_DIR.parents[1]
+BUILD = "release"
+FILENAME = "translator-usage.md"
+
+INTRO_TEXT = """
+# Translator
+
+Fast Downward's PDDL to SAS^+ translator can be called through Fast Downward's driver script
+
+```
+./fast-downward.py --translate [domain] problem [--translate-options OPTIONS]
+```
+
+"""
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--outdir", default=f"{REPO_ROOT_DIR}/docs")
+    return parser.parse_args()
+
+
+def build_translator():
+    subprocess.check_call([sys.executable, "build.py", BUILD, "translate"], cwd=REPO_ROOT_DIR)
+
+
+def import_argparser_from_translator():
+    sys.path.insert(0, str(REPO_ROOT_DIR / "builds" / BUILD / "bin"))
+    from translate import options
+    return options.get_arg_parser()
+
+
+def parser_to_markdown(parser: argparse.ArgumentParser):
+    lines = [INTRO_TEXT]
+    lines.append("## Options")
+    lines.append("")
+
+    for action in parser._actions:
+        if action.option_strings:
+            name = ", ".join(f"`{s}`" for s in action.option_strings)
+        else:
+            name = f"`{action.dest}`"
+        lines.append(f"### {name}")
+        lines.append(action.help)
+        lines.append("")
+    return "\n".join(lines)
+
+
+def build_docs(path: Path):
+    parser = import_argparser_from_translator()
+    path.write_text(parser_to_markdown(parser))
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    logging.info("building translator...")
+    build_translator()
+    logging.info("building documentation...")
+    outdir = SCRIPT_DIR / args.outdir
+    outdir.mkdir(parents=True, exist_ok=True)
+    outpath = outdir / FILENAME
+    if outpath.exists():
+        sys.exit(f"{outpath} already exists.")
+    build_docs(outpath)

--- a/misc/autodoc/generate-translate-docs.py
+++ b/misc/autodoc/generate-translate-docs.py
@@ -12,7 +12,7 @@ BUILD = "release"
 FILENAME = "translator-usage.md"
 
 INTRO_TEXT = """
-# Translator
+# Translator Usage
 
 Fast Downward's PDDL to SAS^+ translator can be called through Fast Downward's driver script
 

--- a/misc/website/build_website.py
+++ b/misc/website/build_website.py
@@ -10,8 +10,8 @@ import sys
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT_DIR = SCRIPT_DIR.parents[1]
 BUILD_DIR = SCRIPT_DIR/"build"
-GENERATED_DOC_DIR = BUILD_DIR/"docs"/"documentation"/"search"
-GENERATED_TRANSLATE_DOC_DIR = BUILD_DIR/"docs"/"documentation"
+GENERATED_DOC_DIR = BUILD_DIR/"docs"/"documentation"
+GENERATED_SEARCH_DOC_DIR = GENERATED_DOC_DIR/"search"
 
 if __name__ == '__main__':
     try:
@@ -32,18 +32,18 @@ if __name__ == '__main__':
     # we remove the search directory from the documentation (in case it is
     # there) because we will re-generate its content in the next step from the
     # actual code (binary).
-    rmtree(GENERATED_DOC_DIR, ignore_errors=True)
+    rmtree(GENERATED_SEARCH_DOC_DIR, ignore_errors=True)
 
     print("Start creating documentation of search plugins")
     subprocess.run(
         [REPO_ROOT_DIR/"misc"/"autodoc"/"generate-docs.py", "--outdir",
-         GENERATED_DOC_DIR])
+         GENERATED_SEARCH_DOC_DIR])
     print("Done creating documentation of search plugins")
 
     print("Start creating documentation of translator")
     subprocess.run(
         [REPO_ROOT_DIR/"misc"/"autodoc"/"generate-translate-docs.py", "--outdir",
-         GENERATED_TRANSLATE_DOC_DIR])
+         GENERATED_DOC_DIR])
     print("Done creating documentation of translator")
 
     print("\n\n", "Done. Run 'mkdocs serve' from the build directory "

--- a/misc/website/build_website.py
+++ b/misc/website/build_website.py
@@ -34,8 +34,11 @@ if __name__ == '__main__':
     rmtree(GENERATED_DOC_DIR, ignore_errors=True)
 
     print("Start creating documentation of search plugins")
-    out = subprocess.run(
+    subprocess.run(
         [REPO_ROOT_DIR/"misc"/"autodoc"/"generate-docs.py", "--outdir",
+         GENERATED_DOC_DIR])
+    subprocess.run(
+        [REPO_ROOT_DIR/"misc"/"autodoc"/"generate-translate-docs.py", "--outdir",
          GENERATED_DOC_DIR])
     print("Done creating documentation of search plugins")
 

--- a/misc/website/build_website.py
+++ b/misc/website/build_website.py
@@ -11,6 +11,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT_DIR = SCRIPT_DIR.parents[1]
 BUILD_DIR = SCRIPT_DIR/"build"
 GENERATED_DOC_DIR = BUILD_DIR/"docs"/"documentation"/"search"
+GENERATED_TRANSLATE_DOC_DIR = BUILD_DIR/"docs"/"documentation"
 
 if __name__ == '__main__':
     try:
@@ -37,10 +38,13 @@ if __name__ == '__main__':
     subprocess.run(
         [REPO_ROOT_DIR/"misc"/"autodoc"/"generate-docs.py", "--outdir",
          GENERATED_DOC_DIR])
+    print("Done creating documentation of search plugins")
+
+    print("Start creating documentation of translator")
     subprocess.run(
         [REPO_ROOT_DIR/"misc"/"autodoc"/"generate-translate-docs.py", "--outdir",
-         GENERATED_DOC_DIR])
-    print("Done creating documentation of search plugins")
+         GENERATED_TRANSLATE_DOC_DIR])
+    print("Done creating documentation of translator")
 
     print("\n\n", "Done. Run 'mkdocs serve' from the build directory "
           "to see the website in the browser at http://localhost:8001/:\n",


### PR DESCRIPTION
Adds a script `misc/autodoc/generate-translate-docs.py` to generate a list of possible translator options for the website and calls it in the corresponding Github action