### PR TITLE
[issue1222] Add translator option for representing disjunctive formulas using derived variables

### DIFF
--- a/src/translate/main.py
+++ b/src/translate/main.py
@@ -695,8 +695,8 @@ def main():
         task = pddl_parser.open(
             domain_filename=get_options().domain, problem_filename=get_options().problem)
 
-    with timers.timing("Normalizing task"):
-        normalize.normalize(task)
+    with timers.timing(f"Normalizing task with strategy {get_options().condition_normalization_strategy}"):
+        normalize.normalize(task, get_options().condition_normalization_strategy)
 
     if get_options().generate_relaxed_task:
         # Remove delete effects.

--- a/src/translate/main.py
+++ b/src/translate/main.py
@@ -696,7 +696,7 @@ def main():
             domain_filename=get_options().domain, problem_filename=get_options().problem)
 
     with timers.timing(f"Normalizing task with strategy {get_options().condition_normalization_strategy}"):
-        normalize.normalize(task, get_options().condition_normalization_strategy)
+        normalize.normalize(task)
 
     if get_options().generate_relaxed_task:
         # Remove delete effects.

--- a/src/translate/main.py
+++ b/src/translate/main.py
@@ -695,7 +695,7 @@ def main():
         task = pddl_parser.open(
             domain_filename=get_options().domain, problem_filename=get_options().problem)
 
-    with timers.timing(f"Normalizing task with strategy {get_options().condition_normalization_strategy}"):
+    with timers.timing("Normalizing task"):
         normalize.normalize(task)
 
     if get_options().generate_relaxed_task:

--- a/src/translate/normalize.py
+++ b/src/translate/normalize.py
@@ -4,6 +4,8 @@ import copy
 from typing import Sequence
 
 from translate import pddl
+from translate.options import get_options
+
 
 class ConditionProxy:
     def clone_owner(self):
@@ -370,16 +372,14 @@ def substitute_complicated_goal(task):
 # Combine Steps [1], [2], [3], [4], [5] and do some additional verification
 # that the task makes sense.
 
-
-def normalize(task, condition_strategy):
+def normalize(task):
     remove_universal_quantifiers(task)
-    if condition_strategy == "dnf":
-        substitute_complicated_goal(task)
-        build_DNF(task)
-    elif condition_strategy == "axiom_based":
-        substitute_conditions_with_axioms(task)
-    else:
-        raise ValueError("Unknown condition normalization strategy: %s" % condition_strategy)
+    match get_options().condition_normalization_strategy:
+        case "dnf":
+            substitute_complicated_goal(task)
+            build_DNF(task)
+        case "axiom_based":
+            substitute_conditions_with_axioms(task)
     split_disjunctions(task)
     move_existential_quantifiers(task)
     eliminate_existential_quantifiers_from_axioms(task)
@@ -463,9 +463,9 @@ def condition_to_rule_body(parameters: Sequence[pddl.TypedObject],
 
 if __name__ == "__main__":
     from translate import pddl_parser
-    from translate.options import get_options, set_options
+    from translate.options import set_options
 
     set_options() # use command line options
     task = pddl_parser.open()
-    normalize(task, get_options().condition_normalization_strategy)
+    normalize(task)
     task.dump()

--- a/src/translate/normalize.py
+++ b/src/translate/normalize.py
@@ -374,12 +374,12 @@ def substitute_complicated_goal(task):
 
 def normalize(task):
     remove_universal_quantifiers(task)
-    match get_options().condition_normalization_strategy:
-        case "dnf":
-            substitute_complicated_goal(task)
-            build_DNF(task)
-        case "axiom_based":
-            substitute_conditions_with_axioms(task)
+    condition_strategy = get_options().condition_normalization_strategy
+    if condition_strategy == "dnf":
+        substitute_complicated_goal(task)
+        build_DNF(task)
+    elif condition_strategy == "axiom_based":
+        substitute_conditions_with_axioms(task)
     split_disjunctions(task)
     move_existential_quantifiers(task)
     eliminate_existential_quantifiers_from_axioms(task)

--- a/src/translate/normalize.py
+++ b/src/translate/normalize.py
@@ -226,6 +226,36 @@ def build_DNF(task):
         if proxy.condition.has_disjunction():
             proxy.set(recurse(proxy.condition).simplified())
 
+# [2 Alternative] Decompose disjunctive formulas using derived predicates.
+# Replace each disjunctive subformula with a derived predicate and add a
+# corresponding axiom defining that predicate. The transformation proceeds
+# bottom-up so nested disjunctions are eliminated first.
+def substitute_conditions_with_axioms(task):
+    def recurse(condition, type_map):
+        if isinstance(condition, (pddl.Literal, pddl.Truth, pddl.Falsity)):
+            return condition
+        elif isinstance(condition, (pddl.Conjunction, pddl.ExistentialCondition)):
+            new_parts = [recurse(part, type_map) for part in condition.parts]
+            condition = condition.change_parts(new_parts)
+            return condition
+        parameters = sorted(condition.free_variables())
+        typed_parameters = tuple(pddl.TypedObject(v, type_map[v]) for v in parameters)
+        key = (condition, typed_parameters)
+        axiom = new_axioms_by_condition.get(key)
+        if not axiom:
+            new_parts = [recurse(part, type_map) for part in condition.parts]
+            condition = condition.change_parts(new_parts)
+            axiom = task.add_axiom(list(typed_parameters), condition)
+            new_axioms_by_condition[key] = axiom
+        return pddl.Atom(axiom.name, parameters)
+
+    new_axioms_by_condition = {}
+
+    for proxy in tuple(all_conditions(task)):
+        # Cannot use generator because we add new axioms on the fly.
+        type_map = proxy.get_type_map()
+        proxy.set(recurse(proxy.condition, type_map))
+
 # [3] Split conditions at the outermost disjunction.
 def split_disjunctions(task):
     for proxy in tuple(all_conditions(task)):
@@ -340,10 +370,16 @@ def substitute_complicated_goal(task):
 # Combine Steps [1], [2], [3], [4], [5] and do some additional verification
 # that the task makes sense.
 
-def normalize(task):
+
+def normalize(task, condition_strategy):
     remove_universal_quantifiers(task)
-    substitute_complicated_goal(task)
-    build_DNF(task)
+    if condition_strategy == "dnf":
+        substitute_complicated_goal(task)
+        build_DNF(task)
+    elif condition_strategy == "axiom_based":
+        substitute_conditions_with_axioms(task)
+    else:
+        raise ValueError("Unknown condition normalization strategy: %s" % condition_strategy)
     split_disjunctions(task)
     move_existential_quantifiers(task)
     eliminate_existential_quantifiers_from_axioms(task)
@@ -427,9 +463,9 @@ def condition_to_rule_body(parameters: Sequence[pddl.TypedObject],
 
 if __name__ == "__main__":
     from translate import pddl_parser
-    from translate.options import set_options
+    from translate.options import get_options, set_options
 
     set_options() # use command line options
     task = pddl_parser.open()
-    normalize(task)
+    normalize(task, get_options().condition_normalization_strategy)
     task.dump()

--- a/src/translate/normalize.py
+++ b/src/translate/normalize.py
@@ -181,15 +181,32 @@ def eliminate_universal_quantifiers(task):
             type_map = proxy.get_type_map()
             proxy.set(recurse(proxy.condition))
 
-# [2] Normalize conditions according to the selected strategy.
-def eliminate_disjunctive_conditions(task):
+# [2] Simplifies conditions according to the selected strategy.
+# After the simplification only conjuncitons
+# and existential conditions remain (+ truth values, literals).
+def simplyfy_conditions(task):
     condition_strategy = get_options().condition_normalization_strategy
     if condition_strategy == "dnf":
         substitute_complicated_goal(task)
         build_DNF(task)
         split_disjunctions(task, all_conditions)
     elif condition_strategy == "axiom_based":
-        substitute_disjunctions_with_derived_predicates(task)
+        substitute_complicated_conditions(task)
+        # Disjunctions can now only occur in axiom bodies
+        split_disjunctions(task, axiom_conditions)
+
+def substitute_complicated_goal(task):
+    goal = task.goal
+    if isinstance(goal, pddl.Literal):
+        return
+    elif isinstance(goal, pddl.Conjunction):
+        for item in goal.parts:
+            if not isinstance(item, pddl.Literal):
+                break
+        else:
+            return
+    new_axiom = task.add_axiom([], goal)
+    task.goal = pddl.Atom(new_axiom.name, new_axiom.parameters)
 
 # Split disjunctions in the task into separate conditions.
 def split_disjunctions(task, condition_generator):
@@ -252,18 +269,19 @@ def build_DNF(task):
         if proxy.condition.has_disjunction():
             proxy.set(recurse(proxy.condition).simplified())
 
-# [2 Option 2] Decompose disjunctive formulas using derived predicates.
-# Replace each disjunctive (sub)formula with a derived predicate and add a
-# corresponding axiom defining that predicate. The transformation proceeds
-# bottom-up so nested disjunctions are eliminated first.
-def substitute_disjunctions_with_derived_predicates(task):
+# [2 Option 2] Decompose disjunctive and existential formulas using derived
+# predicates. Replace each disjunctive (sub)formula with a derived predicate
+# and add a corresponding axiom defining that predicate. The transformation
+# proceeds bottom-up so nested disjunctions are eliminated first.
+def substitute_complicated_conditions(task):
     def recurse(condition, type_map):
         if isinstance(condition, (pddl.Literal, pddl.Truth, pddl.Falsity)):
             return condition
-        elif isinstance(condition, (pddl.Conjunction, pddl.ExistentialCondition)):
+        elif isinstance(condition, pddl.Conjunction):
             new_parts = [recurse(part, type_map) for part in condition.parts]
             condition = condition.change_parts(new_parts)
             return condition
+        assert isinstance(condition, (pddl.Disjunction, pddl.ExistentialCondition))
         parameters = sorted(condition.free_variables())
         typed_parameters = tuple(pddl.TypedObject(v, type_map[v]) for v in parameters)
         key = (condition, typed_parameters)
@@ -281,9 +299,6 @@ def substitute_disjunctions_with_derived_predicates(task):
         # Cannot use generator because we add new axioms on the fly.
         type_map = proxy.get_type_map()
         proxy.set(recurse(proxy.condition, type_map))
-
-    # Disjunctions can now only occur in axiom bodies
-    split_disjunctions(task, axiom_conditions)
 
 # [3] Eliminate existential quantifiers from conditions.
 def eliminate_existential_quantifiers(task):
@@ -378,25 +393,12 @@ def eliminate_existential_quantifiers_from_conditional_effects(task):
                 effect.parameters.extend(condition.parameters)
                 effect.condition = condition.parts[0]
 
-def substitute_complicated_goal(task):
-    goal = task.goal
-    if isinstance(goal, pddl.Literal):
-        return
-    elif isinstance(goal, pddl.Conjunction):
-        for item in goal.parts:
-            if not isinstance(item, pddl.Literal):
-                break
-        else:
-            return
-    new_axiom = task.add_axiom([], goal)
-    task.goal = pddl.Atom(new_axiom.name, new_axiom.parameters)
-
 # Combine Steps [1], [2], [3] and do some additional verification
 # that the task makes sense.
 
 def normalize(task):
     eliminate_universal_quantifiers(task)
-    eliminate_disjunctive_conditions(task)
+    simplyfy_conditions(task)
     eliminate_existential_quantifiers(task)
 
     verify_axiom_predicates(task)

--- a/src/translate/normalize.py
+++ b/src/translate/normalize.py
@@ -186,13 +186,14 @@ def eliminate_universal_quantifiers(task):
 def simplify_conditions(task):
     condition_strategy = get_options().condition_normalization_strategy
 
-    if condition_strategy in ("dnf", "axiomatize_disjunctions"):
-        substitute_complicated_goal(task)
-
     if condition_strategy == "dnf":
+        substitute_complicated_goal(task)
         build_DNF(task)
-    elif condition_strategy in ("axiomatize_disjunctions", "axiomatize_disjunctions_existentials"):
-        substitute_complicated_conditions(task, condition_strategy)
+    elif condition_strategy == "axiomatize_disjunctions":
+        substitute_complicated_goal(task)
+        substitute_complicated_conditions(task, replace_existentials=False)
+    elif condition_strategy == "axiomatize_disjunctions_existentials":
+        substitute_complicated_conditions(task, replace_existentials=True)
     else:
         raise SystemExit("error: unknown condition normalization strategy: %s" % condition_strategy)
 
@@ -272,11 +273,11 @@ def build_DNF(task):
         if proxy.condition.has_disjunction():
             proxy.set(recurse(proxy.condition).simplified())
 
-# [2 Option 2] Decompose disjunctive and existential formulas using derived
-# predicates. Replace each disjunctive (sub)formula with a derived predicate
+# [2 Option 2] Decompose disjunctive and optinally existential formulas using
+# derived predicates. Replace the (sub)formula with a derived predicate
 # and add a corresponding axiom defining that predicate. The transformation
-# proceeds bottom-up so nested disjunctions are eliminated first.
-def substitute_complicated_conditions(task, condition_strategy):
+# proceeds bottom-up so nested (sub)formula are eliminated first.
+def substitute_complicated_conditions(task, replace_existentials):
     def recurse(condition, type_map, replace_types):
         if isinstance(condition, (pddl.Literal, pddl.Truth, pddl.Falsity)):
             return condition
@@ -298,12 +299,7 @@ def substitute_complicated_conditions(task, condition_strategy):
 
     new_axioms_by_condition = {}
 
-    if condition_strategy == "axiomatize_disjunctions":
-        for proxy in tuple(all_conditions(task)):
-            type_map = proxy.get_type_map()
-            proxy.set(recurse(proxy.condition, type_map, (pddl.Disjunction)))
-    else:
-        assert condition_strategy == "axiomatize_disjunctions_existentials"
+    if replace_existentials:
         for proxy in tuple(all_conditions(task, actions=False, axioms=True, goal=False)):
             type_map = proxy.get_type_map()
             proxy.set(recurse(proxy.condition, type_map, (pddl.Disjunction)))
@@ -311,6 +307,11 @@ def substitute_complicated_conditions(task, condition_strategy):
         for proxy in tuple(all_conditions(task, actions=True, axioms=False, goal=True)):
             type_map = proxy.get_type_map()
             proxy.set(recurse(proxy.condition, type_map, (pddl.Disjunction, pddl.ExistentialCondition)))
+    else:
+        for proxy in tuple(all_conditions(task)):
+            type_map = proxy.get_type_map()
+            proxy.set(recurse(proxy.condition, type_map, (pddl.Disjunction)))
+
 
 # [3] Eliminate existential quantifiers from conditions.
 def eliminate_existential_quantifiers(task):

--- a/src/translate/normalize.py
+++ b/src/translate/normalize.py
@@ -135,6 +135,10 @@ def get_axiom_predicate(axiom):
 def get_pne_definition_predicate(pne: pddl.PrimitiveNumericExpression):
     return pddl.Atom(f"@def-{pne.symbol}", pne.args)
 
+def axiom_conditions(task):
+    for axiom in task.axioms:
+        yield AxiomConditionProxy(axiom)
+
 def all_conditions(task):
     for action in task.actions:
         yield PreconditionProxy(action)
@@ -144,7 +148,7 @@ def all_conditions(task):
         yield AxiomConditionProxy(axiom)
     yield GoalConditionProxy(task)
 
-# [1] Remove universal quantifications from conditions.
+# [1] Eliminate universal quantifications from conditions.
 #
 # Replace, in a top-down fashion, <forall(vars, phi)> by <not(not-all-phi)>,
 # where <not-all-phi> is a new axiom.
@@ -153,7 +157,7 @@ def all_conditions(task):
 # translated to NNF. The parameters of the new axioms are exactly the free
 # variables of <forall(vars, phi)>.
 
-def remove_universal_quantifiers(task):
+def eliminate_universal_quantifiers(task):
     def recurse(condition):
         # Uses new_axioms_by_condition and type_map from surrounding scope.
         if isinstance(condition, pddl.UniversalCondition):
@@ -178,13 +182,25 @@ def remove_universal_quantifiers(task):
             proxy.set(recurse(proxy.condition))
 
 # [2] Normalize conditions according to the selected strategy.
-def normalize_conditions(task):
+def eliminate_disjunctive_conditions(task):
     condition_strategy = get_options().condition_normalization_strategy
     if condition_strategy == "dnf":
         substitute_complicated_goal(task)
         build_DNF(task)
-    elif condition_strategy == "derived_predicates":
-        eliminate_disjunctive_conditions(task)
+        split_disjunctions(task, all_conditions)
+    elif condition_strategy == "axiom_based":
+        substitute_disjunctions_with_derived_predicates(task)
+
+# Split disjunctions in the task into separate conditions.
+def split_disjunctions(task, condition_generator):
+    for proxy in tuple(condition_generator(task)):
+        # Cannot use generator directly because we add/delete entries.
+        if isinstance(proxy.condition, pddl.Disjunction):
+            for part in proxy.condition.parts:
+                new_proxy = proxy.clone_owner()
+                new_proxy.set(part)
+                new_proxy.register_owner(task)
+            proxy.delete_owner(task)
 
 # [2 Option 1] Pull disjunctions to the root of the condition.
 #
@@ -240,7 +256,7 @@ def build_DNF(task):
 # Replace each disjunctive (sub)formula with a derived predicate and add a
 # corresponding axiom defining that predicate. The transformation proceeds
 # bottom-up so nested disjunctions are eliminated first.
-def eliminate_disjunctive_conditions(task):
+def substitute_disjunctions_with_derived_predicates(task):
     def recurse(condition, type_map):
         if isinstance(condition, (pddl.Literal, pddl.Truth, pddl.Falsity)):
             return condition
@@ -266,18 +282,17 @@ def eliminate_disjunctive_conditions(task):
         type_map = proxy.get_type_map()
         proxy.set(recurse(proxy.condition, type_map))
 
-# [3] Split conditions at the outermost disjunction.
-def split_disjunctions(task):
-    for proxy in tuple(all_conditions(task)):
-        # Cannot use generator directly because we add/delete entries.
-        if isinstance(proxy.condition, pddl.Disjunction):
-            for part in proxy.condition.parts:
-                new_proxy = proxy.clone_owner()
-                new_proxy.set(part)
-                new_proxy.register_owner(task)
-            proxy.delete_owner(task)
+    # Disjunctions can now only occur in axiom bodies
+    split_disjunctions(task, axiom_conditions)
 
-# [4] Pull existential quantifiers out of conjunctions and group them.
+# [3] Eliminate existential quantifiers from conditions.
+def eliminate_existential_quantifiers(task):
+    move_existential_quantifiers(task)
+    eliminate_existential_quantifiers_from_axioms(task)
+    eliminate_existential_quantifiers_from_preconditions(task)
+    eliminate_existential_quantifiers_from_conditional_effects(task)
+
+# [3a] Pull existential quantifiers out of conjunctions and group them.
 #
 # After removing universal quantifiers and creating the disjunctive form,
 # only the following (representatives of) rules are needed:
@@ -317,13 +332,7 @@ def move_existential_quantifiers(task):
         if proxy.condition.has_existential_part():
             proxy.set(recurse(proxy.condition).simplified())
 
-# [5] Eliminate existential quantifiers from conditions.
-def eliminate_existential_quantifiers(task):
-    eliminate_existential_quantifiers_from_axioms(task)
-    eliminate_existential_quantifiers_from_preconditions(task)
-    eliminate_existential_quantifiers_from_conditional_effects(task)
-
-# [5a] Drop existential quantifiers from axioms, turning them
+# [3b] Drop existential quantifiers from axioms, turning them
 #      into parameters.
 
 def eliminate_existential_quantifiers_from_axioms(task):
@@ -341,7 +350,7 @@ def eliminate_existential_quantifiers_from_axioms(task):
             axiom.condition = precond.parts[0]
 
 
-# [5b] Drop existential quantifiers from action preconditions,
+# [3c] Drop existential quantifiers from action preconditions,
 #      turning them into action parameters (that don't form part of the
 #      name of the action).
 
@@ -356,7 +365,7 @@ def eliminate_existential_quantifiers_from_preconditions(task):
             action.parameters.extend(precond.parameters)
             action.precondition = precond.parts[0]
 
-# [5c] Eliminate existential quantifiers from effect conditions
+# [3d] Eliminate existential quantifiers from effect conditions
 #
 # For effect conditions, we replace "when exists(x, phi) then e" with
 # "forall(x): when phi then e.
@@ -382,14 +391,12 @@ def substitute_complicated_goal(task):
     new_axiom = task.add_axiom([], goal)
     task.goal = pddl.Atom(new_axiom.name, new_axiom.parameters)
 
-# Combine Steps [1], [2], [3], [4], [5] and do some additional verification
+# Combine Steps [1], [2], [3] and do some additional verification
 # that the task makes sense.
 
 def normalize(task):
-    remove_universal_quantifiers(task)
-    normalize_conditions(task)
-    split_disjunctions(task)
-    move_existential_quantifiers(task)
+    eliminate_universal_quantifiers(task)
+    eliminate_disjunctive_conditions(task)
     eliminate_existential_quantifiers(task)
 
     verify_axiom_predicates(task)
@@ -417,7 +424,7 @@ def verify_axiom_predicates(task):
                     (effect.literal.predicate, action.name))
 
 
-# [6] Build rules for exploration component.
+# Build rules for exploration component.
 def build_exploration_rules(task):
     result = []
     for proxy in all_conditions(task):

--- a/src/translate/normalize.py
+++ b/src/translate/normalize.py
@@ -177,8 +177,16 @@ def remove_universal_quantifiers(task):
             type_map = proxy.get_type_map()
             proxy.set(recurse(proxy.condition))
 
+# [2] Normalize conditions according to the selected strategy.
+def normalize_conditions(task):
+    condition_strategy = get_options().condition_normalization_strategy
+    if condition_strategy == "dnf":
+        substitute_complicated_goal(task)
+        build_DNF(task)
+    elif condition_strategy == "derived_predicates":
+        eliminate_disjunctive_conditions(task)
 
-# [2] Pull disjunctions to the root of the condition.
+# [2 Option 1] Pull disjunctions to the root of the condition.
 #
 # After removing universal quantifiers, the (k-ary generalization of the)
 # following rules suffice for doing that:
@@ -228,11 +236,11 @@ def build_DNF(task):
         if proxy.condition.has_disjunction():
             proxy.set(recurse(proxy.condition).simplified())
 
-# [2 Alternative] Decompose disjunctive formulas using derived predicates.
-# Replace each disjunctive subformula with a derived predicate and add a
+# [2 Option 2] Decompose disjunctive formulas using derived predicates.
+# Replace each disjunctive (sub)formula with a derived predicate and add a
 # corresponding axiom defining that predicate. The transformation proceeds
 # bottom-up so nested disjunctions are eliminated first.
-def substitute_conditions_with_axioms(task):
+def eliminate_disjunctive_conditions(task):
     def recurse(condition, type_map):
         if isinstance(condition, (pddl.Literal, pddl.Truth, pddl.Falsity)):
             return condition
@@ -309,6 +317,11 @@ def move_existential_quantifiers(task):
         if proxy.condition.has_existential_part():
             proxy.set(recurse(proxy.condition).simplified())
 
+# [5] Eliminate existential quantifiers from conditions.
+def eliminate_existential_quantifiers(task):
+    eliminate_existential_quantifiers_from_axioms(task)
+    eliminate_existential_quantifiers_from_preconditions(task)
+    eliminate_existential_quantifiers_from_conditional_effects(task)
 
 # [5a] Drop existential quantifiers from axioms, turning them
 #      into parameters.
@@ -374,17 +387,10 @@ def substitute_complicated_goal(task):
 
 def normalize(task):
     remove_universal_quantifiers(task)
-    condition_strategy = get_options().condition_normalization_strategy
-    if condition_strategy == "dnf":
-        substitute_complicated_goal(task)
-        build_DNF(task)
-    elif condition_strategy == "axiom_based":
-        substitute_conditions_with_axioms(task)
+    normalize_conditions(task)
     split_disjunctions(task)
     move_existential_quantifiers(task)
-    eliminate_existential_quantifiers_from_axioms(task)
-    eliminate_existential_quantifiers_from_preconditions(task)
-    eliminate_existential_quantifiers_from_conditional_effects(task)
+    eliminate_existential_quantifiers(task)
 
     verify_axiom_predicates(task)
 

--- a/src/translate/normalize.py
+++ b/src/translate/normalize.py
@@ -139,14 +139,17 @@ def axiom_conditions(task):
     for axiom in task.axioms:
         yield AxiomConditionProxy(axiom)
 
-def all_conditions(task):
-    for action in task.actions:
-        yield PreconditionProxy(action)
-        for effect in action.effects:
-            yield EffectConditionProxy(action, effect)
-    for axiom in task.axioms:
-        yield AxiomConditionProxy(axiom)
-    yield GoalConditionProxy(task)
+def all_conditions(task, actions=True, axioms=True, goal=True):
+    if actions:
+        for action in task.actions:
+            yield PreconditionProxy(action)
+            for effect in action.effects:
+                yield EffectConditionProxy(action, effect)
+    if axioms:
+        for axiom in task.axioms:
+            yield AxiomConditionProxy(axiom)
+    if goal:
+        yield GoalConditionProxy(task)
 
 # [1] Eliminate universal quantifications from conditions.
 #
@@ -184,16 +187,24 @@ def eliminate_universal_quantifiers(task):
 # [2] Simplifies conditions according to the selected strategy.
 # After the simplification only conjuncitons
 # and existential conditions remain (+ truth values, literals).
-def simplyfy_conditions(task):
+def simplify_conditions(task):
     condition_strategy = get_options().condition_normalization_strategy
-    if condition_strategy == "dnf":
+
+    if condition_strategy in ("dnf", "axiomatize_disjunctions"):
         substitute_complicated_goal(task)
+
+    if condition_strategy == "dnf":
         build_DNF(task)
         split_disjunctions(task, all_conditions)
-    elif condition_strategy == "axiom_based":
-        substitute_complicated_conditions(task)
-        # Disjunctions can now only occur in axiom bodies
+    elif condition_strategy == "axiomatize_disjunctions":
+        substitute_complicated_conditions(task, condition_strategy)
         split_disjunctions(task, axiom_conditions)
+    elif condition_strategy == "axiomatize_disjunctions_existentials":
+        substitute_complicated_conditions(task, condition_strategy)
+        split_disjunctions(task, axiom_conditions)
+    else:
+        raise SystemExit("Unknown condition normalization strategy: "
+        "%s" % condition_strategy)
 
 def substitute_complicated_goal(task):
     goal = task.goal
@@ -273,21 +284,21 @@ def build_DNF(task):
 # predicates. Replace each disjunctive (sub)formula with a derived predicate
 # and add a corresponding axiom defining that predicate. The transformation
 # proceeds bottom-up so nested disjunctions are eliminated first.
-def substitute_complicated_conditions(task):
-    def recurse(condition, type_map):
+def substitute_complicated_conditions(task, condition_strategy):
+    def recurse(condition, type_map, replace_types):
         if isinstance(condition, (pddl.Literal, pddl.Truth, pddl.Falsity)):
             return condition
-        elif isinstance(condition, pddl.Conjunction):
-            new_parts = [recurse(part, type_map) for part in condition.parts]
+        elif not isinstance(condition, replace_types):
+            new_parts = [recurse(part, type_map, replace_types) for part in condition.parts]
             condition = condition.change_parts(new_parts)
             return condition
-        assert isinstance(condition, (pddl.Disjunction, pddl.ExistentialCondition))
+        assert isinstance(condition, replace_types)
         parameters = sorted(condition.free_variables())
         typed_parameters = tuple(pddl.TypedObject(v, type_map[v]) for v in parameters)
         key = (condition, typed_parameters)
         axiom = new_axioms_by_condition.get(key)
         if not axiom:
-            new_parts = [recurse(part, type_map) for part in condition.parts]
+            new_parts = [recurse(part, type_map, replace_types) for part in condition.parts]
             condition = condition.change_parts(new_parts)
             axiom = task.add_axiom(list(typed_parameters), condition)
             new_axioms_by_condition[key] = axiom
@@ -295,10 +306,19 @@ def substitute_complicated_conditions(task):
 
     new_axioms_by_condition = {}
 
-    for proxy in tuple(all_conditions(task)):
-        # Cannot use generator because we add new axioms on the fly.
-        type_map = proxy.get_type_map()
-        proxy.set(recurse(proxy.condition, type_map))
+    if condition_strategy == "axiomatize_disjunctions":
+        for proxy in tuple(all_conditions(task)):
+            type_map = proxy.get_type_map()
+            proxy.set(recurse(proxy.condition, type_map, (pddl.Disjunction)))
+    else:
+        assert condition_strategy == "axiomatize_disjunctions_existentials"
+        for proxy in tuple(all_conditions(task, actions=False, axioms=True, goal=False)):
+            type_map = proxy.get_type_map()
+            proxy.set(recurse(proxy.condition, type_map, (pddl.Disjunction)))
+
+        for proxy in tuple(all_conditions(task, actions=True, axioms=False, goal=True)):
+            type_map = proxy.get_type_map()
+            proxy.set(recurse(proxy.condition, type_map, (pddl.Disjunction, pddl.ExistentialCondition)))
 
 # [3] Eliminate existential quantifiers from conditions.
 def eliminate_existential_quantifiers(task):
@@ -398,7 +418,7 @@ def eliminate_existential_quantifiers_from_conditional_effects(task):
 
 def normalize(task):
     eliminate_universal_quantifiers(task)
-    simplyfy_conditions(task)
+    simplify_conditions(task)
     eliminate_existential_quantifiers(task)
 
     verify_axiom_predicates(task)

--- a/src/translate/normalize.py
+++ b/src/translate/normalize.py
@@ -135,10 +135,6 @@ def get_axiom_predicate(axiom):
 def get_pne_definition_predicate(pne: pddl.PrimitiveNumericExpression):
     return pddl.Atom(f"@def-{pne.symbol}", pne.args)
 
-def axiom_conditions(task):
-    for axiom in task.axioms:
-        yield AxiomConditionProxy(axiom)
-
 def all_conditions(task, actions=True, axioms=True, goal=True):
     if actions:
         for action in task.actions:
@@ -195,16 +191,12 @@ def simplify_conditions(task):
 
     if condition_strategy == "dnf":
         build_DNF(task)
-        split_disjunctions(task, all_conditions)
-    elif condition_strategy == "axiomatize_disjunctions":
+    elif condition_strategy in ("axiomatize_disjunctions", "axiomatize_disjunctions_existentials"):
         substitute_complicated_conditions(task, condition_strategy)
-        split_disjunctions(task, axiom_conditions)
-    elif condition_strategy == "axiomatize_disjunctions_existentials":
-        substitute_complicated_conditions(task, condition_strategy)
-        split_disjunctions(task, axiom_conditions)
     else:
-        raise SystemExit("Unknown condition normalization strategy: "
-        "%s" % condition_strategy)
+        raise SystemExit("error: unknown condition normalization strategy: %s" % condition_strategy)
+
+    split_disjunctions(task)
 
 def substitute_complicated_goal(task):
     goal = task.goal
@@ -220,8 +212,8 @@ def substitute_complicated_goal(task):
     task.goal = pddl.Atom(new_axiom.name, new_axiom.parameters)
 
 # Split disjunctions in the task into separate conditions.
-def split_disjunctions(task, condition_generator):
-    for proxy in tuple(condition_generator(task)):
+def split_disjunctions(task):
+    for proxy in tuple(all_conditions(task)):
         # Cannot use generator directly because we add/delete entries.
         if isinstance(proxy.condition, pddl.Disjunction):
             for part in proxy.condition.parts:

--- a/src/translate/options.py
+++ b/src/translate/options.py
@@ -86,6 +86,12 @@ def get_arg_parser():
         help="How to assign layers to derived variables. 'min' attempts to put as "
         "many variables into the same layer as possible, while 'max' puts each variable "
         "into its own layer unless it is part of a cycle.")
+    argparser.add_argument(
+        "--condition-normalization-strategy", default="dnf", choices=["dnf", "axiom_based"],
+        help="Strategy for normalizing PDDL conditions. 'dnf' uses disjunctive normal form "
+        "which may cause exponential blow-up for complex conditions. 'axiom_based' uses "
+        "axioms to represent complex conditions, avoiding blow-up but increasing "
+        "the number of axioms.")
     return argparser
 
 

--- a/src/translate/options.py
+++ b/src/translate/options.py
@@ -87,12 +87,11 @@ def get_arg_parser():
         "many variables into the same layer as possible, while 'max' puts each variable "
         "into its own layer unless it is part of a cycle.")
     argparser.add_argument(
-        "--condition-normalization-strategy", default="dnf", choices=["dnf", "derived_predicates"],
-        help="Strategy for normalizing PDDL conditions. 'dnf' converts conditions to disjunctive "
-        "normal form, which may causeexponential blow-up for complex conditions. "
-        "'derived_predicates' replaces complex subformulas with derived predicates and introduces "
-        "axioms defining them, avoiding the blow-up at the cost of additional derived predicates "
-        "and axioms.")
+        "--condition-normalization-strategy", default="dnf", choices=["dnf", "axiom_based"],
+        help="Strategy for normalizing PDDL conditions. The 'dnf' strategy uses disjunctive "
+        "normal form, which may cause exponential blow-up for complex conditions. The "
+        "'axiom_based' strategy uses axioms to represent complex conditions, avoiding blow-up "
+        "but increasing the number of axioms.")
     return argparser
 
 

--- a/src/translate/options.py
+++ b/src/translate/options.py
@@ -87,11 +87,12 @@ def get_arg_parser():
         "many variables into the same layer as possible, while 'max' puts each variable "
         "into its own layer unless it is part of a cycle.")
     argparser.add_argument(
-        "--condition-normalization-strategy", default="dnf", choices=["dnf", "axiom_based"],
-        help="Strategy for normalizing PDDL conditions. 'dnf' uses disjunctive normal form "
-        "which may cause exponential blow-up for complex conditions. 'axiom_based' uses "
-        "axioms to represent complex conditions, avoiding blow-up but increasing "
-        "the number of axioms.")
+        "--condition-normalization-strategy", default="dnf", choices=["dnf", "derived_predicates"],
+        help="Strategy for normalizing PDDL conditions. 'dnf' converts conditions to disjunctive "
+        "normal form, which may causeexponential blow-up for complex conditions. "
+        "'derived_predicates'replaces complex subformulas with derived predicates and introduces "
+        "axioms defining them, avoiding the blow-up at the cost of additional derived predicates "
+        "and axioms.")
     return argparser
 
 

--- a/src/translate/options.py
+++ b/src/translate/options.py
@@ -87,11 +87,13 @@ def get_arg_parser():
         "many variables into the same layer as possible, while 'max' puts each variable "
         "into its own layer unless it is part of a cycle.")
     argparser.add_argument(
-        "--condition-normalization-strategy", default="dnf", choices=["dnf", "axiom_based"],
-        help="Strategy for normalizing PDDL conditions. The 'dnf' strategy uses disjunctive "
-        "normal form, which may cause exponential blow-up for complex conditions. The "
-        "'axiom_based' strategy uses axioms to represent complex conditions, avoiding blow-up "
-        "but increasing the number of axioms.")
+        "--condition-normalization-strategy", default="dnf",
+        choices=["dnf", "axiom_based"],
+        help="Strategy for normalizing PDDL conditions. The 'dnf' strategy "
+        "uses disjunctive normal form, which may cause exponential blow-up "
+        "for complicated conditions. The 'axiom_based' strategy uses axioms "
+        "to represent complicated conditions, avoiding blow-up but increasing "
+        "the number of axioms.")
     return argparser
 
 

--- a/src/translate/options.py
+++ b/src/translate/options.py
@@ -87,13 +87,23 @@ def get_arg_parser():
         "many variables into the same layer as possible, while 'max' puts each variable "
         "into its own layer unless it is part of a cycle.")
     argparser.add_argument(
-        "--condition-normalization-strategy", default="dnf",
-        choices=["dnf", "axiom_based"],
-        help="Strategy for normalizing PDDL conditions. The 'dnf' strategy "
-        "uses disjunctive normal form, which may cause exponential blow-up "
-        "for complicated conditions. The 'axiom_based' strategy uses axioms "
-        "to represent complicated conditions, avoiding blow-up but increasing "
-        "the number of axioms.")
+        "--condition-normalization-strategy",
+        default="dnf",
+        choices=[
+            "dnf",
+            "axiomatize_disjunctions",
+            "axiomatize_disjunctions_existentials",
+        ],
+        help="Strategy for normalizing PDDL conditions. Strategy 'dnf' converts "
+        "conditions to disjunctive normal form, which may cause exponential "
+        "blow-up for complex formulas but introduces few derived predicates. "
+        "Strategy 'axiomatize_disjunctions' replaces every disjunction by a derived "
+        "predicate, avoiding the DNF blow-up while preserving existential "
+        "quantifiers. Strategy 'axiomatize_disjunctions_existentials' additionally replaces "
+        "existential quantifiers in action conditions and goals with derived "
+        "predicates. This typically introduces more derived predicates but "
+        "avoids creating multiple operator instances."
+    )
     return argparser
 
 

--- a/src/translate/options.py
+++ b/src/translate/options.py
@@ -90,7 +90,7 @@ def get_arg_parser():
         "--condition-normalization-strategy", default="dnf", choices=["dnf", "derived_predicates"],
         help="Strategy for normalizing PDDL conditions. 'dnf' converts conditions to disjunctive "
         "normal form, which may causeexponential blow-up for complex conditions. "
-        "'derived_predicates'replaces complex subformulas with derived predicates and introduces "
+        "'derived_predicates' replaces complex subformulas with derived predicates and introduces "
         "axioms defining them, avoiding the blow-up at the cost of additional derived predicates "
         "and axioms.")
     return argparser


### PR DESCRIPTION
The translator has now an option `condition-normalization-strategy` which allows to choice between the following two options.
- `dnf` (default): The previous strategy to handle disjunctions in conditions. It produces a dnf and splits the condition. For the goal it may substitute at the highest level using axioms.
- `axioms_based` (new): Decompose disjunctive formulas using derived predicates. It replaces each disjunctive subformula with a derived predicate and add a corresponding axiom defining that predicate. The transformation proceeds bottom-up so nested disjunctions are eliminated first. 
