### PR TITLE
[issue1228] alternative precondition choice functions for LM-Cut

### DIFF
--- a/src/search/heuristics/lm_cut_heuristic.cc
+++ b/src/search/heuristics/lm_cut_heuristic.cc
@@ -14,9 +14,9 @@ using namespace std;
 
 namespace lm_cut_heuristic {
 LandmarkCutHeuristic::LandmarkCutHeuristic(
-    const shared_ptr<AbstractTask> &task, bool cache_estimates,
-    const string &description, utils::Verbosity verbosity,
-    bool use_goal_zone_detection, bool use_border_detection)
+    const shared_ptr<AbstractTask> &task, bool use_goal_zone_detection,
+    bool use_border_detection, bool cache_estimates, const string &description,
+    utils::Verbosity verbosity)
     : Heuristic(task, cache_estimates, description, verbosity),
       landmark_generator(make_unique<LandmarkCutLandmarks>(
           task_proxy, use_goal_zone_detection, use_border_detection)) {
@@ -60,8 +60,8 @@ public:
         const plugins::Options &opts) const override {
         return components::make_auto_task_independent_component<
             LandmarkCutHeuristic, Evaluator>(
-            get_heuristic_arguments_from_options(opts),
-            get_landmark_cut_landmarks_arguments_from_options(opts));
+            get_landmark_cut_landmarks_arguments_from_options(opts),
+            get_heuristic_arguments_from_options(opts));
     }
 };
 

--- a/src/search/heuristics/lm_cut_heuristic.cc
+++ b/src/search/heuristics/lm_cut_heuristic.cc
@@ -43,20 +43,7 @@ public:
     LandmarkCutHeuristicFeature() : TypedFeature("lmcut") {
         document_title("Landmark-cut heuristic");
 
-        add_option<bool>(
-            "goal_zone_detection",
-            "when choosing the h^max supporter of a zero-cost operator while "
-            "marking the goal zone, break ties in favor of a precondition "
-            "that already belongs to the goal zone.",
-            "false");
-
-        add_option<bool>(
-            "border_detection",
-            "when choosing the h^max supporter of a zero-cost operator while "
-            "marking the goal zone, break ties in favor of a precondition "
-            "on the border of the goal zone.",
-            "false");
-
+        add_landmark_cut_landmarks_options_to_feature(*this);
         add_heuristic_options_to_feature(*this, "lmcut");
 
         document_language_support("action costs", "supported");
@@ -74,8 +61,7 @@ public:
         return components::make_auto_task_independent_component<
             LandmarkCutHeuristic, Evaluator>(
             get_heuristic_arguments_from_options(opts),
-            opts.get<bool>("goal_zone_detection"),
-            opts.get<bool>("border_detection"));
+            get_landmark_cut_landmarks_arguments_from_options(opts));
     }
 };
 

--- a/src/search/heuristics/lm_cut_heuristic.cc
+++ b/src/search/heuristics/lm_cut_heuristic.cc
@@ -18,7 +18,8 @@ LandmarkCutHeuristic::LandmarkCutHeuristic(
     const string &description, utils::Verbosity verbosity,
     bool use_goal_zone_detection, bool use_border_detection)
     : Heuristic(task, cache_estimates, description, verbosity),
-      landmark_generator(make_unique<LandmarkCutLandmarks>(task_proxy, use_goal_zone_detection, use_border_detection)) {
+      landmark_generator(make_unique<LandmarkCutLandmarks>(
+          task_proxy, use_goal_zone_detection, use_border_detection)) {
     if (log.is_at_least_normal()) {
         log << "Initializing landmark cut heuristic..." << endl;
     }
@@ -44,12 +45,16 @@ public:
 
         add_option<bool>(
             "goal_zone_detection",
-            "TODO",
+            "when choosing the h^max supporter of a zero-cost operator while "
+            "marking the goal zone, break ties in favor of a precondition "
+            "that already belongs to the goal zone.",
             "false");
 
         add_option<bool>(
             "border_detection",
-            "TODO",
+            "when choosing the h^max supporter of a zero-cost operator while "
+            "marking the goal zone, break ties in favor of a precondition "
+            "on the border of the goal zone.",
             "false");
 
         add_heuristic_options_to_feature(*this, "lmcut");

--- a/src/search/heuristics/lm_cut_heuristic.cc
+++ b/src/search/heuristics/lm_cut_heuristic.cc
@@ -15,9 +15,10 @@ using namespace std;
 namespace lm_cut_heuristic {
 LandmarkCutHeuristic::LandmarkCutHeuristic(
     const shared_ptr<AbstractTask> &task, bool cache_estimates,
-    const string &description, utils::Verbosity verbosity)
+    const string &description, utils::Verbosity verbosity,
+    bool use_goal_zone_detection, bool use_border_detection)
     : Heuristic(task, cache_estimates, description, verbosity),
-      landmark_generator(make_unique<LandmarkCutLandmarks>(task_proxy)) {
+      landmark_generator(make_unique<LandmarkCutLandmarks>(task_proxy, use_goal_zone_detection, use_border_detection)) {
     if (log.is_at_least_normal()) {
         log << "Initializing landmark cut heuristic..." << endl;
     }
@@ -41,6 +42,16 @@ public:
     LandmarkCutHeuristicFeature() : TypedFeature("lmcut") {
         document_title("Landmark-cut heuristic");
 
+        add_option<bool>(
+            "goal_zone_detection",
+            "TODO",
+            "false");
+
+        add_option<bool>(
+            "border_detection",
+            "TODO",
+            "false");
+
         add_heuristic_options_to_feature(*this, "lmcut");
 
         document_language_support("action costs", "supported");
@@ -57,7 +68,9 @@ public:
         const plugins::Options &opts) const override {
         return components::make_auto_task_independent_component<
             LandmarkCutHeuristic, Evaluator>(
-            get_heuristic_arguments_from_options(opts));
+            get_heuristic_arguments_from_options(opts),
+            opts.get<bool>("goal_zone_detection"),
+            opts.get<bool>("border_detection"));
     }
 };
 

--- a/src/search/heuristics/lm_cut_heuristic.cc
+++ b/src/search/heuristics/lm_cut_heuristic.cc
@@ -7,6 +7,7 @@
 #include "../plugins/plugin.h"
 #include "../task_utils/task_properties.h"
 #include "../utils/logging.h"
+#include "../utils/markup.h"
 
 #include <iostream>
 
@@ -42,6 +43,18 @@ class LandmarkCutHeuristicFeature
 public:
     LandmarkCutHeuristicFeature() : TypedFeature("lmcut") {
         document_title("Landmark-cut heuristic");
+        document_synopsis(
+            "This heuristic implements tie-breaking strategies for the "
+            "precondition choice function (options {{{goal_zone_detection}}} "
+            "and {{{border_detection}}}) described in the following paper:" +
+            utils::format_conference_reference(
+                {"Pascal Lauer", "Maximilian Fickert"},
+                "Beating LM-cut with LM-cut: Quick Cutting and Practical Tie "
+                "Breaking for the Precondition Choice Function",
+                "https://fai.cs.uni-saarland.de/lauer/papers/hsdip2020.pdf",
+                "Proceedings of the 12th Workshop on Heuristic Search for "
+                "Domain-Independent Planning (HSDIP 2020)",
+                "9-15", "", "2020"));
 
         add_landmark_cut_landmarks_options_to_feature(*this);
         add_heuristic_options_to_feature(*this, "lmcut");

--- a/src/search/heuristics/lm_cut_heuristic.h
+++ b/src/search/heuristics/lm_cut_heuristic.h
@@ -15,7 +15,8 @@ class LandmarkCutHeuristic : public Heuristic {
 public:
     LandmarkCutHeuristic(
         const std::shared_ptr<AbstractTask> &task, bool cache_estimates,
-        const std::string &description, utils::Verbosity verbosity);
+        const std::string &description, utils::Verbosity verbosity,
+        bool use_goal_zone_detection, bool use_border_detection);
 };
 }
 

--- a/src/search/heuristics/lm_cut_heuristic.h
+++ b/src/search/heuristics/lm_cut_heuristic.h
@@ -14,9 +14,9 @@ class LandmarkCutHeuristic : public Heuristic {
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     LandmarkCutHeuristic(
-        const std::shared_ptr<AbstractTask> &task, bool cache_estimates,
-        const std::string &description, utils::Verbosity verbosity,
-        bool use_goal_zone_detection, bool use_border_detection);
+        const std::shared_ptr<AbstractTask> &task, bool use_goal_zone_detection,
+        bool use_border_detection, bool cache_estimates,
+        const std::string &description, utils::Verbosity verbosity);
 };
 }
 

--- a/src/search/heuristics/lm_cut_landmarks.cc
+++ b/src/search/heuristics/lm_cut_landmarks.cc
@@ -263,15 +263,12 @@ void LandmarkCutLandmarks::break_supporter_ties(RelaxedOperator *op) {
 }
 
 void LandmarkCutLandmarks::mark_goal_plateau(RelaxedProposition *subgoal) {
-    // NOTE: subgoal can be null if we got here via recursion through
-    // a zero-cost action that is relaxed unreachable. (This can only
-    // happen in domains which have zero-cost actions to start with.)
-/*
-  NOTE: subgoal can be null if we got here via recursion through
-  a zero-cost action that is relaxed unreachable. (This can only
-  happen in domains which have zero-cost actions to start with.)
-  For example, this happens in pegsol-strips #01.
-*/
+    /*
+      NOTE: subgoal can be null if we got here via recursion through
+      a zero-cost action that is relaxed unreachable. (This can only
+      happen in domains which have zero-cost actions to start with.)
+      For example, this happens in pegsol-strips #01.
+    */
     if (subgoal && subgoal->status != GOAL_ZONE) {
         subgoal->status = GOAL_ZONE;
         for (RelaxedOperator *achiever : subgoal->effect_of)
@@ -284,13 +281,11 @@ void LandmarkCutLandmarks::mark_goal_plateau(RelaxedProposition *subgoal) {
 
 void LandmarkCutLandmarks::validate_h_max() const {
 #ifndef NDEBUG
-    // Using conditional compilation to avoid complaints about unused
-    // variables when using NDEBUG. This whole code does nothing useful
-/*
-  Using conditional compilation to avoid complaints about unused
-  variables when using NDEBUG. This whole code does nothing useful
-  when assertions are switched off anyway.
-*/
+    /*
+      Using conditional compilation to avoid complaints about unused
+      variables when using NDEBUG. This whole code does nothing useful
+      when assertions are switched off anyway.
+    */
     for (const RelaxedOperator &op : relaxed_operators) {
         if (op.unsatisfied_preconditions) {
             bool reachable = true;
@@ -321,15 +316,12 @@ bool LandmarkCutLandmarks::compute_landmarks(
     for (RelaxedOperator &op : relaxed_operators) {
         op.cost = op.base_cost;
     }
-    // The following three variables could be declared inside the loop
-    // ("second_exploration_queue" even inside second_exploration),
-    // but having them here saves reallocations and hence provides a
-/*
-  The following three variables could be declared inside the loop
-  ("second_exploration_queue" even inside second_exploration),
-  but having them here saves reallocations and hence provides a
-  measurable speed boost.
-*/
+    /*
+      The following three variables could be declared inside the loop
+      ("second_exploration_queue" even inside second_exploration),
+      but having them here saves reallocations and hence provides a
+      measurable speed boost.
+    */
     vector<RelaxedOperator *> cut;
     Landmark landmark;
     vector<RelaxedProposition *> second_exploration_queue;

--- a/src/search/heuristics/lm_cut_landmarks.cc
+++ b/src/search/heuristics/lm_cut_landmarks.cc
@@ -234,11 +234,7 @@ void LandmarkCutLandmarks::second_exploration(
     }
 }
 
-/*
-  A proposition is on the border of the goal zone if it can not be achieved by
-  operators with zero cost.
-*/
-static bool is_border(const RelaxedProposition *prop) {
+static bool has_no_zero_cost_achiever(const RelaxedProposition *prop) {
     for (const RelaxedOperator *op : prop->effect_of) {
         if (op->cost == 0) {
             return false;
@@ -255,7 +251,7 @@ void LandmarkCutLandmarks::tie_break_supporter(RelaxedOperator *op) {
         if (pre->h_max_cost != op->h_max_supporter_cost) {
             continue;
         }
-        if (use_border_detection && is_border(pre)) {
+        if (use_border_detection && has_no_zero_cost_achiever(pre)) {
             op->h_max_supporter = pre;
             break;
         }

--- a/src/search/heuristics/lm_cut_landmarks.cc
+++ b/src/search/heuristics/lm_cut_landmarks.cc
@@ -324,7 +324,12 @@ bool LandmarkCutLandmarks::compute_landmarks(
     // The following three variables could be declared inside the loop
     // ("second_exploration_queue" even inside second_exploration),
     // but having them here saves reallocations and hence provides a
-    // measurable speed boost.
+/*
+  The following three variables could be declared inside the loop
+  ("second_exploration_queue" even inside second_exploration),
+  but having them here saves reallocations and hence provides a
+  measurable speed boost.
+*/
     vector<RelaxedOperator *> cut;
     Landmark landmark;
     vector<RelaxedProposition *> second_exploration_queue;

--- a/src/search/heuristics/lm_cut_landmarks.cc
+++ b/src/search/heuristics/lm_cut_landmarks.cc
@@ -1,9 +1,11 @@
 #include "lm_cut_landmarks.h"
 
+#include "../plugins/plugin.h"
 #include "../task_utils/task_properties.h"
 
 #include <algorithm>
 #include <limits>
+#include <tuple>
 #include <utility>
 
 using namespace std;
@@ -14,7 +16,8 @@ LandmarkCutLandmarks::LandmarkCutLandmarks(
     const TaskProxy &task_proxy, bool use_goal_zone_detection,
     bool use_border_detection)
     : use_goal_zone_detection(use_goal_zone_detection),
-      use_border_detection(use_border_detection) {
+      use_border_detection(use_border_detection),
+      dont_tie_break(!use_border_detection && !use_goal_zone_detection) {
     task_properties::verify_no_axioms(task_proxy);
     task_properties::verify_no_conditional_effects(task_proxy);
 
@@ -245,6 +248,9 @@ static bool is_border(const RelaxedProposition *prop) {
 }
 
 void LandmarkCutLandmarks::tie_break_supporter(RelaxedOperator *op) {
+    if (dont_tie_break) {
+        return;
+    }
     for (RelaxedProposition *pre : op->preconditions) {
         if (pre->h_max_cost != op->h_max_supporter_cost) {
             continue;
@@ -364,5 +370,28 @@ bool LandmarkCutLandmarks::compute_landmarks(
         artificial_precondition.status = REACHED;
     }
     return false;
+}
+
+void add_landmark_cut_landmarks_options_to_feature(plugins::Feature &feature) {
+    feature.add_option<bool>(
+        "goal_zone_detection",
+        "When choosing the h^max supporter of a zero-cost operator while "
+        "marking the goal zone, break ties in favor of a precondition "
+        "that already belongs to the goal zone.",
+        "false");
+    feature.add_option<bool>(
+        "border_detection",
+        "When choosing the h^max supporter of a zero-cost operator while "
+        "marking the goal zone, break ties in favor of a precondition "
+        "on the border of the goal zone (a proposition reachable only "
+        "through operators with positive cost).",
+        "false");
+}
+
+tuple<bool, bool> get_landmark_cut_landmarks_arguments_from_options(
+    const plugins::Options &opts) {
+    return make_tuple(
+        opts.get<bool>("goal_zone_detection"),
+        opts.get<bool>("border_detection"));
 }
 }

--- a/src/search/heuristics/lm_cut_landmarks.cc
+++ b/src/search/heuristics/lm_cut_landmarks.cc
@@ -266,7 +266,12 @@ void LandmarkCutLandmarks::mark_goal_plateau(RelaxedProposition *subgoal) {
     // NOTE: subgoal can be null if we got here via recursion through
     // a zero-cost action that is relaxed unreachable. (This can only
     // happen in domains which have zero-cost actions to start with.)
-    // For example, this happens in pegsol-strips #01.
+/*
+  NOTE: subgoal can be null if we got here via recursion through
+  a zero-cost action that is relaxed unreachable. (This can only
+  happen in domains which have zero-cost actions to start with.)
+  For example, this happens in pegsol-strips #01.
+*/
     if (subgoal && subgoal->status != GOAL_ZONE) {
         subgoal->status = GOAL_ZONE;
         for (RelaxedOperator *achiever : subgoal->effect_of)

--- a/src/search/heuristics/lm_cut_landmarks.cc
+++ b/src/search/heuristics/lm_cut_landmarks.cc
@@ -286,7 +286,11 @@ void LandmarkCutLandmarks::validate_h_max() const {
 #ifndef NDEBUG
     // Using conditional compilation to avoid complaints about unused
     // variables when using NDEBUG. This whole code does nothing useful
-    // when assertions are switched off anyway.
+/*
+  Using conditional compilation to avoid complaints about unused
+  variables when using NDEBUG. This whole code does nothing useful
+  when assertions are switched off anyway.
+*/
     for (const RelaxedOperator &op : relaxed_operators) {
         if (op.unsatisfied_preconditions) {
             bool reachable = true;

--- a/src/search/heuristics/lm_cut_landmarks.cc
+++ b/src/search/heuristics/lm_cut_landmarks.cc
@@ -10,7 +10,13 @@ using namespace std;
 
 namespace lm_cut_heuristic {
 // construction and destruction
-LandmarkCutLandmarks::LandmarkCutLandmarks(const TaskProxy &task_proxy) {
+LandmarkCutLandmarks::LandmarkCutLandmarks(
+    const TaskProxy &task_proxy,
+    bool use_goal_zone_detection,
+    bool use_border_detection)
+    : use_goal_zone_detection(use_goal_zone_detection),
+      use_border_detection(use_border_detection) {
+
     task_properties::verify_no_axioms(task_proxy);
     task_properties::verify_no_conditional_effects(task_proxy);
 
@@ -227,6 +233,30 @@ void LandmarkCutLandmarks::second_exploration(
     }
 }
 
+static inline bool is_border(RelaxedProposition *p) {
+    for (RelaxedOperator *op : p->effect_of)
+        if (op->cost == 0)
+            return false;
+    return true;
+}
+
+void LandmarkCutLandmarks::tie_break_supporter(RelaxedOperator *op) {
+    for (auto *pre : op->preconditions) {
+        if (use_border_detection
+            && pre->h_max_cost == op->h_max_supporter_cost
+            && is_border(pre)) {
+            op->h_max_supporter = pre;
+            break;
+        }
+        if (use_goal_zone_detection
+            && pre->h_max_cost == op->h_max_supporter_cost
+            && pre->status == GOAL_ZONE) {
+            op->h_max_supporter = pre;
+            break;
+        }
+    }
+}
+
 void LandmarkCutLandmarks::mark_goal_plateau(RelaxedProposition *subgoal) {
     // NOTE: subgoal can be null if we got here via recursion through
     // a zero-cost action that is relaxed unreachable. (This can only
@@ -235,8 +265,10 @@ void LandmarkCutLandmarks::mark_goal_plateau(RelaxedProposition *subgoal) {
     if (subgoal && subgoal->status != GOAL_ZONE) {
         subgoal->status = GOAL_ZONE;
         for (RelaxedOperator *achiever : subgoal->effect_of)
-            if (achiever->cost == 0)
+            if (achiever->cost == 0) {
+                tie_break_supporter(achiever);
                 mark_goal_plateau(achiever->h_max_supporter);
+            }
     }
 }
 

--- a/src/search/heuristics/lm_cut_landmarks.cc
+++ b/src/search/heuristics/lm_cut_landmarks.cc
@@ -11,12 +11,10 @@ using namespace std;
 namespace lm_cut_heuristic {
 // construction and destruction
 LandmarkCutLandmarks::LandmarkCutLandmarks(
-    const TaskProxy &task_proxy,
-    bool use_goal_zone_detection,
+    const TaskProxy &task_proxy, bool use_goal_zone_detection,
     bool use_border_detection)
     : use_goal_zone_detection(use_goal_zone_detection),
       use_border_detection(use_border_detection) {
-
     task_properties::verify_no_axioms(task_proxy);
     task_properties::verify_no_conditional_effects(task_proxy);
 
@@ -233,24 +231,29 @@ void LandmarkCutLandmarks::second_exploration(
     }
 }
 
-static inline bool is_border(RelaxedProposition *p) {
-    for (RelaxedOperator *op : p->effect_of)
-        if (op->cost == 0)
+/*
+  A proposition is on the border of the goal zone if it can not be achieved by
+  operators with zero cost.
+*/
+static bool is_border(const RelaxedProposition *prop) {
+    for (const RelaxedOperator *op : prop->effect_of) {
+        if (op->cost == 0) {
             return false;
+        }
+    }
     return true;
 }
 
 void LandmarkCutLandmarks::tie_break_supporter(RelaxedOperator *op) {
-    for (auto *pre : op->preconditions) {
-        if (use_border_detection
-            && pre->h_max_cost == op->h_max_supporter_cost
-            && is_border(pre)) {
+    for (RelaxedProposition *pre : op->preconditions) {
+        if (pre->h_max_cost != op->h_max_supporter_cost) {
+            continue;
+        }
+        if (use_border_detection && is_border(pre)) {
             op->h_max_supporter = pre;
             break;
         }
-        if (use_goal_zone_detection
-            && pre->h_max_cost == op->h_max_supporter_cost
-            && pre->status == GOAL_ZONE) {
+        if (use_goal_zone_detection && pre->status == GOAL_ZONE) {
             op->h_max_supporter = pre;
             break;
         }

--- a/src/search/heuristics/lm_cut_landmarks.cc
+++ b/src/search/heuristics/lm_cut_landmarks.cc
@@ -243,7 +243,7 @@ static bool has_no_zero_cost_achiever(const RelaxedProposition *prop) {
     return true;
 }
 
-void LandmarkCutLandmarks::tie_break_supporter(RelaxedOperator *op) {
+void LandmarkCutLandmarks::break_supporter_ties(RelaxedOperator *op) {
     if (dont_tie_break) {
         return;
     }
@@ -276,7 +276,7 @@ void LandmarkCutLandmarks::mark_goal_plateau(RelaxedProposition *subgoal) {
         subgoal->status = GOAL_ZONE;
         for (RelaxedOperator *achiever : subgoal->effect_of)
             if (achiever->cost == 0) {
-                tie_break_supporter(achiever);
+                break_supporter_ties(achiever);
                 mark_goal_plateau(achiever->h_max_supporter);
             }
     }

--- a/src/search/heuristics/lm_cut_landmarks.cc
+++ b/src/search/heuristics/lm_cut_landmarks.cc
@@ -378,14 +378,14 @@ void add_landmark_cut_landmarks_options_to_feature(plugins::Feature &feature) {
         "When choosing the h^max supporter of a zero-cost operator while "
         "marking the goal zone, break ties in favor of a precondition "
         "that already belongs to the goal zone.",
-        "false");
+        "true");
     feature.add_option<bool>(
         "border_detection",
         "When choosing the h^max supporter of a zero-cost operator while "
         "marking the goal zone, break ties in favor of a precondition "
         "on the border of the goal zone (a proposition reachable only "
         "through operators with positive cost).",
-        "false");
+        "true");
 }
 
 tuple<bool, bool> get_landmark_cut_landmarks_arguments_from_options(

--- a/src/search/heuristics/lm_cut_landmarks.h
+++ b/src/search/heuristics/lm_cut_landmarks.h
@@ -96,7 +96,7 @@ class LandmarkCutLandmarks {
         }
     }
 
-    void tie_break_supporter(RelaxedOperator *op);
+    void break_supporter_ties(RelaxedOperator *op);
     void mark_goal_plateau(RelaxedProposition *subgoal);
     void validate_h_max() const;
 public:

--- a/src/search/heuristics/lm_cut_landmarks.h
+++ b/src/search/heuristics/lm_cut_landmarks.h
@@ -8,7 +8,13 @@
 #include <cassert>
 #include <functional>
 #include <memory>
+#include <tuple>
 #include <vector>
+
+namespace plugins {
+class Feature;
+class Options;
+}
 
 namespace lm_cut_heuristic {
 // TODO: Fix duplication with the other relaxation heuristics.
@@ -58,6 +64,7 @@ struct RelaxedProposition {
 class LandmarkCutLandmarks {
     bool use_goal_zone_detection;
     bool use_border_detection;
+    bool dont_tie_break;
 
     std::vector<RelaxedOperator> relaxed_operators;
     std::vector<std::vector<RelaxedProposition>> propositions;
@@ -126,6 +133,11 @@ inline void RelaxedOperator::update_h_max_supporter() {
             h_max_supporter = preconditions[i];
     h_max_supporter_cost = h_max_supporter->h_max_cost;
 }
+
+extern void add_landmark_cut_landmarks_options_to_feature(
+    plugins::Feature &feature);
+extern std::tuple<bool, bool> get_landmark_cut_landmarks_arguments_from_options(
+    const plugins::Options &opts);
 }
 
 #endif

--- a/src/search/heuristics/lm_cut_landmarks.h
+++ b/src/search/heuristics/lm_cut_landmarks.h
@@ -56,8 +56,8 @@ struct RelaxedProposition {
 };
 
 class LandmarkCutLandmarks {
-    bool use_border_detection;
     bool use_goal_zone_detection;
+    bool use_border_detection;
 
     std::vector<RelaxedOperator> relaxed_operators;
     std::vector<std::vector<RelaxedProposition>> propositions;
@@ -97,7 +97,9 @@ public:
     using CostCallback = std::function<void(int)>;
     using LandmarkCallback = std::function<void(const Landmark &, int)>;
 
-    LandmarkCutLandmarks(const TaskProxy &task_proxy, bool use_border_detection, bool use_goal_zone_detection);
+    LandmarkCutLandmarks(
+        const TaskProxy &task_proxy, bool use_goal_zone_detection,
+        bool use_border_detection);
 
     /*
       Compute LM-cut landmarks for the given state.

--- a/src/search/heuristics/lm_cut_landmarks.h
+++ b/src/search/heuristics/lm_cut_landmarks.h
@@ -56,6 +56,9 @@ struct RelaxedProposition {
 };
 
 class LandmarkCutLandmarks {
+    bool use_border_detection;
+    bool use_goal_zone_detection;
+
     std::vector<RelaxedOperator> relaxed_operators;
     std::vector<std::vector<RelaxedProposition>> propositions;
     RelaxedProposition artificial_precondition;
@@ -86,6 +89,7 @@ class LandmarkCutLandmarks {
         }
     }
 
+    void tie_break_supporter(RelaxedOperator *op);
     void mark_goal_plateau(RelaxedProposition *subgoal);
     void validate_h_max() const;
 public:
@@ -93,7 +97,7 @@ public:
     using CostCallback = std::function<void(int)>;
     using LandmarkCallback = std::function<void(const Landmark &, int)>;
 
-    LandmarkCutLandmarks(const TaskProxy &task_proxy);
+    LandmarkCutLandmarks(const TaskProxy &task_proxy, bool use_border_detection, bool use_goal_zone_detection);
 
     /*
       Compute LM-cut landmarks for the given state.

--- a/src/search/operator_counting/lm_cut_constraints.cc
+++ b/src/search/operator_counting/lm_cut_constraints.cc
@@ -18,8 +18,10 @@ LMCutConstraints::LMCutConstraints(const shared_ptr<AbstractTask> &task)
 void LMCutConstraints::initialize_constraints(
     const shared_ptr<AbstractTask> &task, lp::LinearProgram &) {
     TaskProxy task_proxy(*task);
-    landmark_generator =
-        make_unique<lm_cut_heuristic::LandmarkCutLandmarks>(task_proxy, false, false); //TODO: this should be parsed properly once we settled on options
+    
+    // TODO: Expose the tie-breaking options (goal zone and border detection)
+    landmark_generator = make_unique<lm_cut_heuristic::LandmarkCutLandmarks>(
+        task_proxy, false, false);
 }
 
 bool LMCutConstraints::update_constraints(

--- a/src/search/operator_counting/lm_cut_constraints.cc
+++ b/src/search/operator_counting/lm_cut_constraints.cc
@@ -18,7 +18,7 @@ LMCutConstraints::LMCutConstraints(const shared_ptr<AbstractTask> &task)
 void LMCutConstraints::initialize_constraints(
     const shared_ptr<AbstractTask> &task, lp::LinearProgram &) {
     TaskProxy task_proxy(*task);
-    
+
     // TODO: Expose the tie-breaking options (goal zone and border detection)
     landmark_generator = make_unique<lm_cut_heuristic::LandmarkCutLandmarks>(
         task_proxy, false, false);

--- a/src/search/operator_counting/lm_cut_constraints.cc
+++ b/src/search/operator_counting/lm_cut_constraints.cc
@@ -19,7 +19,7 @@ void LMCutConstraints::initialize_constraints(
     const shared_ptr<AbstractTask> &task, lp::LinearProgram &) {
     TaskProxy task_proxy(*task);
     landmark_generator =
-        make_unique<lm_cut_heuristic::LandmarkCutLandmarks>(task_proxy);
+        make_unique<lm_cut_heuristic::LandmarkCutLandmarks>(task_proxy, false, false); //TODO: this should be parsed properly once we settled on options
 }
 
 bool LMCutConstraints::update_constraints(

--- a/src/search/operator_counting/lm_cut_constraints.cc
+++ b/src/search/operator_counting/lm_cut_constraints.cc
@@ -11,17 +11,19 @@
 using namespace std;
 
 namespace operator_counting {
-LMCutConstraints::LMCutConstraints(const shared_ptr<AbstractTask> &task)
-    : ConstraintGenerator(task) {
+LMCutConstraints::LMCutConstraints(
+    const shared_ptr<AbstractTask> &task, bool use_goal_zone_detection,
+    bool use_border_detection)
+    : ConstraintGenerator(task),
+      use_goal_zone_detection(use_goal_zone_detection),
+      use_border_detection(use_border_detection) {
 }
 
 void LMCutConstraints::initialize_constraints(
     const shared_ptr<AbstractTask> &task, lp::LinearProgram &) {
     TaskProxy task_proxy(*task);
-
-    // TODO: Expose the tie-breaking options (goal zone and border detection)
     landmark_generator = make_unique<lm_cut_heuristic::LandmarkCutLandmarks>(
-        task_proxy, false, false);
+        task_proxy, use_goal_zone_detection, use_border_detection);
 }
 
 bool LMCutConstraints::update_constraints(
@@ -74,12 +76,16 @@ public:
                 "Proceedings of the Twenty-Third International Joint"
                 " Conference on Artificial Intelligence (IJCAI 2013)",
                 "2268-2274", "AAAI Press", "2013"));
+
+        lm_cut_heuristic::add_landmark_cut_landmarks_options_to_feature(*this);
     }
 
     virtual shared_ptr<TaskIndependentConstraintGenerator> create_component(
-        const plugins::Options &) const override {
+        const plugins::Options &opts) const override {
         return components::make_auto_task_independent_component<
-            LMCutConstraints, ConstraintGenerator>();
+            LMCutConstraints, ConstraintGenerator>(
+            lm_cut_heuristic::get_landmark_cut_landmarks_arguments_from_options(
+                opts));
     }
 };
 

--- a/src/search/operator_counting/lm_cut_constraints.h
+++ b/src/search/operator_counting/lm_cut_constraints.h
@@ -11,9 +11,13 @@ class LandmarkCutLandmarks;
 
 namespace operator_counting {
 class LMCutConstraints : public ConstraintGenerator {
+    bool use_goal_zone_detection;
+    bool use_border_detection;
     std::unique_ptr<lm_cut_heuristic::LandmarkCutLandmarks> landmark_generator;
 public:
-    explicit LMCutConstraints(const std::shared_ptr<AbstractTask> &task);
+    LMCutConstraints(
+        const std::shared_ptr<AbstractTask> &task, bool use_goal_zone_detection,
+        bool use_border_detection);
     virtual void initialize_constraints(
         const std::shared_ptr<AbstractTask> &task,
         lp::LinearProgram &lp) override;


### PR DESCRIPTION
This is a pull request for [issue1228](https://issues.fast-downward.org/issue1228).

Open questions:

- [x] Did we reproduce the increase in coverage from Max and my paper?
- [x] Should we implement the [TODO](https://github.com/PLauerRocks/downward-pcf-lmcut/blob/af26add5b5b52b95ff9c9250d2ad117158e54d6d/src/search/operator_counting/lm_cut_constraints.cc#L22) to introduce a flag for operator counting constraints based on LM-Cut.
- [x] In the comments I refer to "goal zone" as in Malte and Carmel's paper. But the functions in the code actually say "goal plateau". Should this be adjusted? If yes, in what way?
- [x] Should the options be enabled by default?
