### PR TITLE
[issue1231] add early stopping to iterated search.

### DIFF
--- a/driver/aliases.py
+++ b/driver/aliases.py
@@ -47,7 +47,7 @@ eager(alt([tiebreaking([sum([g(),weight(hAdd,10)]),hAdd]),
            tiebreaking([sum([g(),weight(hgc,10)]),hgc],pref_only=true)],
           boost=500),
       preferred=[hcea,hgc],reopen_closed=true,cost_type=normal)
-],repeat_last=true,continue_on_fail=true))))))"""]
+],repeat_last=true))))))"""]
 
 ALIASES["seq-sat-fd-autotune-2"] = [
     "--search",
@@ -87,7 +87,7 @@ lazy(alt([single(sum([g(),weight(hff,2)])),
           single(sum([g(),weight(hgc,2)]),pref_only=true)],
          boost=1000),
      preferred=[hcea,hgc],reopen_closed=true,cost_type=one)
-],repeat_last=true,continue_on_fail=true)))))"""]
+],repeat_last=true)))))"""]
 
 def _get_lama(pref):
     return [
@@ -101,7 +101,7 @@ def _get_lama(pref):
             lazy_wastar([hff,hlm],preferred=[hff,hlm],w=3),
             lazy_wastar([hff,hlm],preferred=[hff,hlm],w=2),
             lazy_wastar([hff,hlm],preferred=[hff,hlm],w=1)
-         ],repeat_last=true,continue_on_fail=true)))""",
+         ],repeat_last=true)))""",
         "--if-non-unit-cost",
         f"let(hlm1, eval_modify_costs(landmark_sum(lm_reasonable_orders_hps(lm_rhw()),pref={pref}),cost_type=one),"
         "let(hff1, eval_modify_costs(ff(),cost_type=one),"
@@ -116,7 +116,7 @@ def _get_lama(pref):
             lazy_wastar([hff2,hlm2],preferred=[hff2,hlm2],w=3),
             lazy_wastar([hff2,hlm2],preferred=[hff2,hlm2],w=2),
             lazy_wastar([hff2,hlm2],preferred=[hff2,hlm2],w=1)
-        ],repeat_last=true,continue_on_fail=true)))))""",
+        ],repeat_last=true)))))""",
         # Append --always to be on the safe side if we want to append
         # additional options later.
         "--always"]

--- a/src/search/search_algorithms/iterated_search.cc
+++ b/src/search/search_algorithms/iterated_search.cc
@@ -15,8 +15,8 @@ namespace iterated_search {
 IteratedSearch::IteratedSearch(
     const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<TaskIndependentSearchAlgorithm>> &algorithm_configs,
-    bool pass_bound, bool repeat_last,
-    bool continue_on_solve, OperatorCost cost_type, int bound, double max_time,
+    bool pass_bound, bool repeat_last, bool continue_on_solve,
+    OperatorCost cost_type, int bound, double max_time,
     const string &description, utils::Verbosity verbosity)
     : SearchAlgorithm(task, cost_type, bound, max_time, description, verbosity),
       task_independent_searches(algorithm_configs),
@@ -253,17 +253,17 @@ protected:
         const shared_ptr<AbstractTask> &task) const {
         return make_shared<IteratedSearch>(
             task, algorithm_configs, pass_bound, repeat_last_phase,
-            continue_on_solve, cost_type, bound, max_time,
-            description, verbosity);
+            continue_on_solve, cost_type, bound, max_time, description,
+            verbosity);
     }
 
 public:
     TaskIndependentIteratedSearch(
         const vector<shared_ptr<TaskIndependentSearchAlgorithm>>
             &algorithm_configs,
-        bool pass_bound, bool repeat_last,
-        bool continue_on_solve, OperatorCost cost_type, int bound,
-        double max_time, const string &description, utils::Verbosity verbosity)
+        bool pass_bound, bool repeat_last, bool continue_on_solve,
+        OperatorCost cost_type, int bound, double max_time,
+        const string &description, utils::Verbosity verbosity)
         : algorithm_configs(algorithm_configs),
           pass_bound(pass_bound),
           repeat_last_phase(repeat_last),

--- a/src/search/search_algorithms/iterated_search.cc
+++ b/src/search/search_algorithms/iterated_search.cc
@@ -213,7 +213,8 @@ SearchStatus IteratedSearch::step_return_value() {
         return SearchStatus::UNSOLVABLE;
     }
     if (best_status == SearchStatus::UNSOLVABLE_WITHIN_BOUND) {
-        log << "No plan with cost " << bound - 1 << " or less exists - stop searching" << endl;
+        log << "No plan with cost " << bound - 1
+            << " or less exists - stop searching" << endl;
         return SearchStatus::UNSOLVABLE_WITHIN_BOUND;
     }
     log << "No solution found - keep searching" << endl;

--- a/src/search/search_algorithms/iterated_search.cc
+++ b/src/search/search_algorithms/iterated_search.cc
@@ -15,14 +15,13 @@ namespace iterated_search {
 IteratedSearch::IteratedSearch(
     const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<TaskIndependentSearchAlgorithm>> &algorithm_configs,
-    bool pass_bound, bool repeat_last, bool continue_on_fail,
+    bool pass_bound, bool repeat_last,
     bool continue_on_solve, OperatorCost cost_type, int bound, double max_time,
     const string &description, utils::Verbosity verbosity)
     : SearchAlgorithm(task, cost_type, bound, max_time, description, verbosity),
       task_independent_searches(algorithm_configs),
       pass_bound(pass_bound),
       repeat_last_phase(repeat_last),
-      continue_on_fail(continue_on_fail),
       continue_on_solve(continue_on_solve),
       phase(0),
       last_phase_found_solution(false),
@@ -100,8 +99,7 @@ shared_ptr<SearchAlgorithm> IteratedSearch::bind_current_search() {
            repeat_last_phase is true, but *not* if we didn't find a
            solution the last time around, since then this search would
            just behave the same way again (assuming determinism, which
-           we might not actually have right now, but strive for). So
-           this overrides continue_on_fail.
+           we might not actually have right now, but strive for).
         */
         if (repeat_last_phase && last_phase_found_solution) {
             return bind_search(num_phases - 1);
@@ -121,7 +119,6 @@ void IteratedSearch::update_best_status(
     }
     SearchStatus current_search_status =
         task_specific_search->get_finished_search_status();
-    assert(current_search_status != SearchStatus::IN_PROGRESS);
 
     switch (current_search_status) {
     case SearchStatus::SOLVED:
@@ -129,8 +126,10 @@ void IteratedSearch::update_best_status(
         best_status = current_search_status;
         break;
     case SearchStatus::UNSOLVABLE_WITHIN_BOUND:
-        /* We ignore inner bounds if the search did not check up to the outer
-           bound. */
+        /*
+           We ignore inner bounds if the inner search did not check up to the
+           outer bound.
+        */
         if (task_specific_search->get_bound() >= bound) {
             best_status = current_search_status;
         }
@@ -153,9 +152,7 @@ SearchStatus IteratedSearch::step() {
     ++phase;
 
     task_specific_search->search();
-
     update_best_status(task_specific_search);
-
     Plan found_plan;
     int plan_cost = 0;
     last_phase_found_solution = task_specific_search->found_solution();
@@ -210,15 +207,17 @@ SearchStatus IteratedSearch::step_return_value() {
             log << "Solution found - stop searching" << endl;
             return SOLVED;
         }
-    } else {
-        if (continue_on_fail) {
-            log << "No solution found - keep searching" << endl;
-            return IN_PROGRESS;
-        } else {
-            log << "No solution found - stop searching" << endl;
-            return get_finished_search_status();
-        }
     }
+    if (best_status == SearchStatus::UNSOLVABLE) {
+        log << "No plan exists - stop searching" << endl;
+        return SearchStatus::UNSOLVABLE;
+    }
+    if (best_status == SearchStatus::UNSOLVABLE_WITHIN_BOUND) {
+        log << "No plan with cost " << bound << " or less exists - stop searching" << endl;
+        return SearchStatus::UNSOLVABLE_WITHIN_BOUND;
+    }
+    log << "No solution found - keep searching" << endl;
+    return IN_PROGRESS;
 }
 
 void IteratedSearch::print_statistics() const {
@@ -242,7 +241,6 @@ class TaskIndependentIteratedSearch
     vector<shared_ptr<TaskIndependentSearchAlgorithm>> algorithm_configs;
     bool pass_bound;
     bool repeat_last_phase;
-    bool continue_on_fail;
     bool continue_on_solve;
     OperatorCost cost_type;
     int bound;
@@ -254,7 +252,7 @@ protected:
         const shared_ptr<AbstractTask> &task) const {
         return make_shared<IteratedSearch>(
             task, algorithm_configs, pass_bound, repeat_last_phase,
-            continue_on_fail, continue_on_solve, cost_type, bound, max_time,
+            continue_on_solve, cost_type, bound, max_time,
             description, verbosity);
     }
 
@@ -262,13 +260,12 @@ public:
     TaskIndependentIteratedSearch(
         const vector<shared_ptr<TaskIndependentSearchAlgorithm>>
             &algorithm_configs,
-        bool pass_bound, bool repeat_last, bool continue_on_fail,
+        bool pass_bound, bool repeat_last,
         bool continue_on_solve, OperatorCost cost_type, int bound,
         double max_time, const string &description, utils::Verbosity verbosity)
         : algorithm_configs(algorithm_configs),
           pass_bound(pass_bound),
           repeat_last_phase(repeat_last),
-          continue_on_fail(continue_on_fail),
           continue_on_solve(continue_on_solve),
           cost_type(cost_type),
           bound(bound),
@@ -295,9 +292,9 @@ public:
             "The iterated search bound is tightened whenever a component finds "
             "a cheaper plan.",
             "true");
-        add_option<bool>("repeat_last", "repeat last phase of search", "false");
         add_option<bool>(
-            "continue_on_fail", "continue search after no solution found",
+            "repeat_last",
+            "repeat the last search phase while it continues finding solutions",
             "false");
         add_option<bool>(
             "continue_on_solve", "continue search after solution found",
@@ -333,7 +330,6 @@ public:
             opts.get_list<shared_ptr<TaskIndependentSearchAlgorithm>>(
                 "algorithm_configs"),
             opts.get<bool>("pass_bound"), opts.get<bool>("repeat_last"),
-            opts.get<bool>("continue_on_fail"),
             opts.get<bool>("continue_on_solve"),
             get_search_algorithm_arguments_from_options(opts));
     }

--- a/src/search/search_algorithms/iterated_search.cc
+++ b/src/search/search_algorithms/iterated_search.cc
@@ -213,7 +213,7 @@ SearchStatus IteratedSearch::step_return_value() {
         return SearchStatus::UNSOLVABLE;
     }
     if (best_status == SearchStatus::UNSOLVABLE_WITHIN_BOUND) {
-        log << "No plan with cost " << bound << " or less exists - stop searching" << endl;
+        log << "No plan with cost " << bound - 1 << " or less exists - stop searching" << endl;
         return SearchStatus::UNSOLVABLE_WITHIN_BOUND;
     }
     log << "No solution found - keep searching" << endl;

--- a/src/search/search_algorithms/iterated_search.h
+++ b/src/search/search_algorithms/iterated_search.h
@@ -16,7 +16,6 @@ class IteratedSearch : public SearchAlgorithm {
         task_independent_searches;
     bool pass_bound;
     bool repeat_last_phase;
-    bool continue_on_fail;
     bool continue_on_solve;
 
     int phase;
@@ -41,7 +40,7 @@ public:
         const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<TaskIndependentSearchAlgorithm>>
             &algorithm_configs,
-        bool pass_bound, bool repeat_last, bool continue_on_fail,
+        bool pass_bound, bool repeat_last,
         bool continue_on_solve, OperatorCost cost_type, int bound,
         double max_time, const std::string &description,
         utils::Verbosity verbosity);

--- a/src/search/search_algorithms/iterated_search.h
+++ b/src/search/search_algorithms/iterated_search.h
@@ -40,10 +40,9 @@ public:
         const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<TaskIndependentSearchAlgorithm>>
             &algorithm_configs,
-        bool pass_bound, bool repeat_last,
-        bool continue_on_solve, OperatorCost cost_type, int bound,
-        double max_time, const std::string &description,
-        utils::Verbosity verbosity);
+        bool pass_bound, bool repeat_last, bool continue_on_solve,
+        OperatorCost cost_type, int bound, double max_time,
+        const std::string &description, utils::Verbosity verbosity);
 
     virtual void save_plan_if_necessary() override;
     virtual void print_statistics() const override;


### PR DESCRIPTION
Instead of having the user pass a `continue_on_fail` flag for the iterated search, we use the completeness checks to detect whether or not continuing the search makes sense, otherwise we stop early.

Existing configs that call the iterated search with `continue_on_fail=<whatever>` should remove this  part as the keyword argument `continue_on_fail` is no longer known to the iterated search.