### PR TITLE
[trivial] Avoid spurious Wstringop-overflow warning.

### DIFF
--- a/src/search/lp/cplex_solver_interface.cc
+++ b/src/search/lp/cplex_solver_interface.cc
@@ -209,8 +209,6 @@ void CplexSolverInterface::CplexColumnsInfo::assign(
 
 void CplexSolverInterface::CplexRowsInfo::assign(
     const named_vector::NamedVector<LPConstraint> &constraints) {
-    rhs.clear();
-    sense.clear();
     int num_rows = constraints.size();
     sense.resize(num_rows);
     rhs.resize(num_rows);


### PR DESCRIPTION
In some cases resizing a vector can lead to a false positive in some GCC
versions. See https://gcc.gnu.org/pipermail/gcc-bugs/2022-July/792353.html
Not clearing the vectors before resizing fixes this and clearing is not
necessary here anyway.